### PR TITLE
Make doc generation deterministic

### DIFF
--- a/tools/generate_docs.py
+++ b/tools/generate_docs.py
@@ -282,7 +282,7 @@ details.field-details .field-content hr {
             shutil.rmtree(dest_images)
         shutil.copytree(src_images, dest_images)
     
-    files = glob.glob(os.path.join(input_dir, '*.yaml'))
+    files = sorted(glob.glob(os.path.join(input_dir, '*.yaml')))
     
     parsed_classes = {}
     parsed_modalities = {}
@@ -334,7 +334,7 @@ details.field-details .field-content hr {
         down = "/".join(c.lower() for c in to_chain) + "/index.html" if to_chain else "index.html"
         return ups + down
 
-    for cls_name, cls_obj in parsed_classes.items():
+    for cls_name, cls_obj in sorted(parsed_classes.items()):
         if cls_name == 'ONDE_UT': continue
         chain = get_inheritance_chain(cls_name)
         allowed_str = '["' + '", "'.join(chain) + '"]'
@@ -360,7 +360,7 @@ details.field-details .field-content hr {
     
     template = Template(CLASS_TEMPLATE)
     
-    for cls_name, cls_obj in parsed_classes.items():
+    for cls_name, cls_obj in sorted(parsed_classes.items()):
         parents = cls_obj.inherits
         children = children_map.get(cls_name, [])
         
@@ -389,7 +389,7 @@ details.field-details .field-content hr {
             unique_classes.add(acc)
                 
         # Find incoming references
-        for other_name, other_obj in parsed_classes.items():
+        for other_name, other_obj in sorted(parsed_classes.items()):
             if other_name == cls_name: continue
             for fname, field in other_obj.fields.items():
                 if cls_name in get_ref_targets(field.hdf5_type):
@@ -404,7 +404,7 @@ details.field-details .field-content hr {
         if not mermaid_lines:
             mermaid_lines.append(f"  {cls_name}")
                 
-        for c in unique_classes:
+        for c in sorted(unique_classes):
             mermaid_lines.append(f'  click {c} href "{get_relative_html_link(cls_name, c)}"')
             
         mermaid_lines.append(f'  style {cls_name} stroke:#3f51b5,stroke-width:3px')
@@ -523,7 +523,7 @@ details.field-details .field-content hr {
         # Generate master diagram
         master_lines = []
         unique_classes = set()
-        for cls_name, cls_obj in parsed_classes.items():
+        for cls_name, cls_obj in sorted(parsed_classes.items()):
             unique_classes.add(cls_name)
             for parent in cls_obj.inherits:
                 master_lines.append(f"  {parent} <|-- {cls_name}")
@@ -535,7 +535,7 @@ details.field-details .field-content hr {
                         master_lines.append(f"  {cls_name} o-- {ref} : {fname}")
                         unique_classes.add(ref)
                     
-        for c in unique_classes:
+        for c in sorted(unique_classes):
             master_lines.append(f'  click {c} href "{get_relative_html_link(None, c)}"')
             
         master_mermaid = "classDiagram\n" + "\n".join(master_lines)
@@ -599,7 +599,7 @@ details.field-details .field-content hr {
         nav_lines.append("  - Implementations:")
         nav_lines.append("    - implementations/index.md")
         
-        for mod_name, mod_obj in parsed_modalities.items():
+        for mod_name, mod_obj in sorted(parsed_modalities.items()):
             mod_filename = f"{mod_name.lower()}.md"
             with open(os.path.join(impl_dir, mod_filename), 'w', encoding='utf-8') as f:
                 fields_meta = []


### PR DESCRIPTION
In order to help check that cosmetic changes in YAML files do not affect the generated documentation, I’m proposing to sort some datastructure, in order to obtain a better reproductibility during documentation generation.