### PR TITLE
class_definitions: YAML files cosmetic changes

### DIFF
--- a/class_definitions/onde_2dcad.yaml
+++ b/class_definitions/onde_2dcad.yaml
@@ -1,49 +1,28 @@
 onde_class: ONDE_2DCAD
 inherits:
 - ONDE_COMPONENT
-description: '**Conventions for 2D CAD components**
-
-
-  The dxf file gives, in the (X, Z) frame, the 2D CAD description of the component,
-  either for a planar or a cylindrical
-
-  extrusion. For 2D extruded components, extrusion is provided by EXTRUSION_TYPE (plane
-  or sylindrical) and
-
-  EXTRUSION_DIMENSION for the length for plane extrusion, the diameter for cylindrical
-  ones.
-
-
-  The CAD field contains a dxf file for 2D CADs.
-
-
-  For 2D CAD specimen with planar extrusion, the origin is implicitly defined as the
-  (0,0) point in the 2D CAD sketch (see
-
-  [Figure 8](onde_2dcad.md)).
-
-
-  ![Convention for the description of a 2D CAD component with planar extrusion](../images/media/2dcad_planar_extrusion.png
-  "Figure 8")
-
-
-  *[Figure 8](onde_2dcad.md): Convention for the description of a 2D CAD component
-  with planar extrusion*
-
-
-  For 2D CAD specimen with cylinder extrusion, the rotation is performed along the
-  X axis of the DXF schema and the 3D
-
-  origin corresponds to the projection on this axis of the 2D CAD sketch origin (see
-  [Figure 9](onde_2dcad.md))
-
-
-  ![Convention for the description of a 2D CAD component with cylinder extrusion](../images/media/2dcad_cylinder_extrusion.png
-  "Figure 9")
-
-
-  *[Figure 9](onde_2dcad.md): Convention for the description of a 2D CAD component
-  with cylinder extrusion*'
+description: |-
+    **Conventions for 2D CAD components**
+  
+    The dxf file gives, in the (X, Z) frame, the 2D CAD description of the component, either for a planar or a cylindrical
+    extrusion. For 2D extruded components, extrusion is provided by EXTRUSION_TYPE (plane or sylindrical) and
+    EXTRUSION_DIMENSION for the length for plane extrusion, the diameter for cylindrical ones.
+  
+    The CAD field contains a dxf file for 2D CADs.
+  
+    For 2D CAD specimen with planar extrusion, the origin is implicitly defined as the (0,0) point in the 2D CAD sketch (see
+    [Figure 8](onde_2dcad.md)).
+  
+    ![Convention for the description of a 2D CAD component with planar extrusion](../images/media/2dcad_planar_extrusion.png "Figure 8")
+  
+    *[Figure 8](onde_2dcad.md): Convention for the description of a 2D CAD component with planar extrusion*
+  
+    For 2D CAD specimen with cylinder extrusion, the rotation is performed along the X axis of the DXF schema and the 3D
+    origin corresponds to the projection on this axis of the 2D CAD sketch origin (see [Figure 9](onde_2dcad.md))
+  
+    ![Convention for the description of a 2D CAD component with cylinder extrusion](../images/media/2dcad_cylinder_extrusion.png "Figure 9")
+  
+    *[Figure 9](onde_2dcad.md): Convention for the description of a 2D CAD component with cylinder extrusion*
 fields:
   EXTRUSION_TYPE:
     full_name: ONDE_2DCAD:EXTRUSION_TYPE

--- a/class_definitions/onde_2dcad.yaml
+++ b/class_definitions/onde_2dcad.yaml
@@ -2,26 +2,26 @@ onde_class: ONDE_2DCAD
 inherits:
 - ONDE_COMPONENT
 description: |-
-    **Conventions for 2D CAD components**
-  
+    #### Conventions for 2D CAD components
+
     The dxf file gives, in the (X, Z) frame, the 2D CAD description of the component, either for a planar or a cylindrical
     extrusion. For 2D extruded components, extrusion is provided by EXTRUSION_TYPE (plane or sylindrical) and
     EXTRUSION_DIMENSION for the length for plane extrusion, the diameter for cylindrical ones.
-  
+
     The CAD field contains a dxf file for 2D CADs.
-  
+
     For 2D CAD specimen with planar extrusion, the origin is implicitly defined as the (0,0) point in the 2D CAD sketch (see
     [Figure 8](onde_2dcad.md)).
-  
+
     ![Convention for the description of a 2D CAD component with planar extrusion](../images/media/2dcad_planar_extrusion.png "Figure 8")
-  
+
     *[Figure 8](onde_2dcad.md): Convention for the description of a 2D CAD component with planar extrusion*
-  
+
     For 2D CAD specimen with cylinder extrusion, the rotation is performed along the X axis of the DXF schema and the 3D
     origin corresponds to the projection on this axis of the 2D CAD sketch origin (see [Figure 9](onde_2dcad.md))
-  
+
     ![Convention for the description of a 2D CAD component with cylinder extrusion](../images/media/2dcad_cylinder_extrusion.png "Figure 9")
-  
+
     *[Figure 9](onde_2dcad.md): Convention for the description of a 2D CAD component with cylinder extrusion*
 fields:
   EXTRUSION_TYPE:

--- a/class_definitions/onde_acquisition_grid.yaml
+++ b/class_definitions/onde_acquisition_grid.yaml
@@ -1,66 +1,37 @@
 onde_class: ONDE_ACQUISITION_GRID
 inherits:
 - ONDE_SPATIAL_TRAJECTORY
-description: '**Grid trajectory**
-
-
-  In order to facilitate the interpretation of trajectories for common cases for which
-  the acquisition grid (1D or 2D) is
-
-  defined, the specification allows to complement the generic TRAJECTORY field (which
-  is mandatory) with grid data. The
-
-  component must be a plane or a cylinder.
-
-
-  At this stage, the specification does not cover the possibility to describe cylindrical
-  or plane grid trajectories on
-
-  CAD specimens, this will be addressed in future versions.
-
-
-  **Grid origin**
-
-
-  The origin and the orientation of the grid (Dx,Dy,alpha) are provided in (x,y) coordinates
-  in the case of a plane specimen, in (x,
-
-  theta) coordinates in the case of a cylinder specimen, theta being the radial direction
-  on the unfolded surface. They are expressed as a 2D transform from the surface component
-
-  frame in UV_GRID_FRAME. For cylindrical components, it is necessary to specify if
-  the inner or the outer surface is
-
-  concerned, which is achieved by setting GRID_CYLINDER_DEFINITION to INNER or OUTER.
-
-
-  This surface component frame is the 2D projection of the component frame on the
-  considered surface (along z for plane
-
-  specimens, along r for cylinder specimens).
-
-
-  **Grid positions**
-
-
-  The grid positions which are targeted during the acquisition are given by U_GRID_DATA
-  and V_GRID_DATA : these specify a
-
-  cartesian grid. The actual values of the coder at each point of the grid are stored
-  in U_ENCODER and V_ENCODER. For 1D
-
-  acquisitions, V_GRID_DATA and V_ENCODER are not to be used.
-
-
-  PROBE_DIRECTION gives the orientation of the probe at each point. It is assumed
-  to be unique for the whole grid.
-
-
-  ![Obtained versus specified coder positions](../images/media/coder_positions.png
-  "Figure 22")
-
-
-  *[Figure 22](onde_acquisition_grid.md): Obtained versus specified coder positions*'
+description: |-
+    **Grid trajectory**
+  
+    In order to facilitate the interpretation of trajectories for common cases for which the acquisition grid (1D or 2D) is
+    defined, the specification allows to complement the generic TRAJECTORY field (which is mandatory) with grid data. The
+    component must be a plane or a cylinder.
+  
+    At this stage, the specification does not cover the possibility to describe cylindrical or plane grid trajectories on
+    CAD specimens, this will be addressed in future versions.
+  
+    **Grid origin**
+  
+    The origin and the orientation of the grid (Dx,Dy,alpha) are provided in (x,y) coordinates in the case of a plane specimen, in (x,
+    theta) coordinates in the case of a cylinder specimen, theta being the radial direction on the unfolded surface. They are expressed as a 2D transform from the surface component
+    frame in UV_GRID_FRAME. For cylindrical components, it is necessary to specify if the inner or the outer surface is
+    concerned, which is achieved by setting GRID_CYLINDER_DEFINITION to INNER or OUTER.
+  
+    This surface component frame is the 2D projection of the component frame on the considered surface (along z for plane
+    specimens, along r for cylinder specimens).
+  
+    **Grid positions**
+  
+    The grid positions which are targeted during the acquisition are given by U_GRID_DATA and V_GRID_DATA : these specify a
+    cartesian grid. The actual values of the coder at each point of the grid are stored in U_ENCODER and V_ENCODER. For 1D
+    acquisitions, V_GRID_DATA and V_ENCODER are not to be used.
+  
+    PROBE_DIRECTION gives the orientation of the probe at each point. It is assumed to be unique for the whole grid.
+  
+    ![Obtained versus specified coder positions](../images/media/coder_positions.png "Figure 22")
+  
+    *[Figure 22](onde_acquisition_grid.md): Obtained versus specified coder positions*
 fields:
   REFERENCE_SPECIMEN:
     full_name: ONDE_ACQUISITION_GRID:REFERENCE_SPECIMEN

--- a/class_definitions/onde_acquisition_grid.yaml
+++ b/class_definitions/onde_acquisition_grid.yaml
@@ -2,35 +2,35 @@ onde_class: ONDE_ACQUISITION_GRID
 inherits:
 - ONDE_SPATIAL_TRAJECTORY
 description: |-
-    **Grid trajectory**
-  
+    #### Grid trajectory
+
     In order to facilitate the interpretation of trajectories for common cases for which the acquisition grid (1D or 2D) is
     defined, the specification allows to complement the generic TRAJECTORY field (which is mandatory) with grid data. The
     component must be a plane or a cylinder.
-  
+
     At this stage, the specification does not cover the possibility to describe cylindrical or plane grid trajectories on
     CAD specimens, this will be addressed in future versions.
-  
-    **Grid origin**
-  
+
+    #### Grid origin
+
     The origin and the orientation of the grid (Dx,Dy,alpha) are provided in (x,y) coordinates in the case of a plane specimen, in (x,
     theta) coordinates in the case of a cylinder specimen, theta being the radial direction on the unfolded surface. They are expressed as a 2D transform from the surface component
     frame in UV_GRID_FRAME. For cylindrical components, it is necessary to specify if the inner or the outer surface is
     concerned, which is achieved by setting GRID_CYLINDER_DEFINITION to INNER or OUTER.
-  
+
     This surface component frame is the 2D projection of the component frame on the considered surface (along z for plane
     specimens, along r for cylinder specimens).
-  
-    **Grid positions**
-  
+
+    #### Grid positions
+
     The grid positions which are targeted during the acquisition are given by U_GRID_DATA and V_GRID_DATA : these specify a
     cartesian grid. The actual values of the coder at each point of the grid are stored in U_ENCODER and V_ENCODER. For 1D
     acquisitions, V_GRID_DATA and V_ENCODER are not to be used.
-  
+
     PROBE_DIRECTION gives the orientation of the probe at each point. It is assumed to be unique for the whole grid.
-  
+
     ![Obtained versus specified coder positions](../images/media/coder_positions.png "Figure 22")
-  
+
     *[Figure 22](onde_acquisition_grid.md): Obtained versus specified coder positions*
 fields:
   REFERENCE_SPECIMEN:

--- a/class_definitions/onde_acquisition_trajectory.yaml
+++ b/class_definitions/onde_acquisition_trajectory.yaml
@@ -1,19 +1,14 @@
 onde_class: ONDE_ACQUISITION_TRAJECTORY
 inherits: []
-description: '### Acquisition trajectory
-
-
-  **Frame used for trajectory definition**
-
-
-  The trajectory is given in the global reference frame.
-
-
-  **Generic description**
-
-
-  A generic description of the trajectory is given in the TRAJECTORY field. It describes
-  successive positions under the
-
-  shape of frames, each giving a position and an orientation.'
+description: |-
+    ### Acquisition trajectory
+  
+    **Frame used for trajectory definition**
+  
+    The trajectory is given in the global reference frame.
+  
+    **Generic description**
+  
+    A generic description of the trajectory is given in the TRAJECTORY field. It describes successive positions under the
+    shape of frames, each giving a position and an orientation.
 fields: {}

--- a/class_definitions/onde_acquisition_trajectory.yaml
+++ b/class_definitions/onde_acquisition_trajectory.yaml
@@ -2,18 +2,7 @@ onde_class: ONDE_ACQUISITION_TRAJECTORY
 inherits: []
 description: '### Acquisition trajectory
 
-
-  **Frame used for trajectory definition**
-
-
-  The trajectory is given in the global reference frame.
-
-
-  **Generic description**
-
-
-  A generic description of the trajectory is given in the TRAJECTORY field. It describes
-  successive positions under the
-
-  shape of frames, each giving a position and an orientation.'
+The acquisition trajectory can be either explicitly described or defined as a series of acquisitions with no spatial locations (which corresponds to a time trigger).
+In the former case, the ONDE_ACQUISITION_TRAJECTORY class is subtyped in the ONDE_SPATIAL_TRAJECTORY class, which describes the spatial trajectory of the acquisition frame.
+In the latter case, the ONDE_ACQUISITION_TRAJECTORY class is subtyped in the ONDE_TIME_TRAJECTORY class, which describes the temporal trajectory of the acquisition frame.'
 fields: {}

--- a/class_definitions/onde_acquisition_trajectory.yaml
+++ b/class_definitions/onde_acquisition_trajectory.yaml
@@ -2,13 +2,13 @@ onde_class: ONDE_ACQUISITION_TRAJECTORY
 inherits: []
 description: |-
     ### Acquisition trajectory
-  
-    **Frame used for trajectory definition**
-  
+
+    #### Frame used for trajectory definition
+
     The trajectory is given in the global reference frame.
-  
-    **Generic description**
-  
+
+    #### Generic description
+
     A generic description of the trajectory is given in the TRAJECTORY field. It describes successive positions under the
     shape of frames, each giving a position and an orientation.
 fields: {}

--- a/class_definitions/onde_component.yaml
+++ b/class_definitions/onde_component.yaml
@@ -1,49 +1,76 @@
 onde_class: ONDE_COMPONENT
 inherits: []
-description: "### Component\n\n**Velocities**\n\nThe two values of the VELOCITIES\
-  \ array indicate the inspected component longitudinal and shear wave velocity\n\
-  respectively. If both velocities (Longitudinal and Shear) are not available, the\
-  \ missing one should be replaced by a\nNaN).\n\nThis version of the format handles\
-  \ only isotropic materials.\n\n**Shape and dimensions**\n\nThe geometric shape of\
-  \ the inspected component is defined by the subclass of ONDE_COMPONENT. It can be\
-  \ \n one of the following: \"ONDE_PLANE\",\"ONDE_CYLINDER\",\n\"ONDE_2DCAD\", \"\
-  ONDE_3DCAD\", \"ONDE_WELD\". While the format is quite generic by handling CAD files,\
-  \ parametric description is \navailable for plane, cylindrical and weld specimens.\
-  \ Other parameterized shapes can be added in future versions.\n\nFor plane components,\
-  \ the dimensions are give by PLATE_DIMENSIONS, with a triplet for length, width\
-  \ and height.\n\nFor cylindrical components, the dimensions are given by CYLINDER_DIMENSIONS,\
-  \ with a triplet for outer diameter,\nthickness, and length.\n\n/* TODO : update\
-  \ with weld descriptions */\n\nFor 2D extruded components and welds, extrusion is\
-  \ provided by EXTRUSION_TYPE (plane or sylindrical) and EXTRUSION_DIMENSION for\n\
-  the length for plane extrusion, the diameter for cylindrical ones.\n\nThe CAD field\
-  \ can contain a STEP or STL file for 3D CADs, a dxf file for 2D CADs.\n\n```mermaid\n\
-  classDiagram\n  component <|-- plane\n  component <|-- cylinder\n  component <|--\
-  \ 2d_cad\n  component <|-- 3d_cad\n  component <|-- weld\n```\n\n**Visualisation\
-  \ CAD**\n\nVISUALISATION_CAD contains a DXF or STL file for the component visualization.\
-  \ When using a dxf file, the profile will be\nextruded linearly or cylindrically\
-  \ according to the component type.\n\n**Transformations**\n\nThe global coordinate\
-  \ system is distinct from the specimen coordinate system : for example, 2D and 3D\
-  \ CAD coordinates\nare defined in the specimen frame and repositioned in the global\
-  \ coordinate system with the transformation defined in\nCOMPONENT_FRAME ([see paragraph\
-  \ 1.6](index.md#definition-of-frames)).\n\n**Visualization CAD**\n\nWhen a dxf is\
-  \ provided for the Visualization CAD, the extrusion of the CAD is implied from the\
-  \ specimen shape : it is of\nlinear nature if the specimen is a plate or a 2D CAD\
-  \ with linear extrusion, it is cylindrical if the specimen is a\ncylinder or a 2D\
-  \ CAD with cylindrical extrusion. A typical use case for this feature is the ability\
-  \ to superimpose a\nweld profile to a plate or cylindrical specimen in order to\
-  \ facilitate the interpretation of the indications.\n\nThe CAD profiles that are\
-  \ used for visualization are expressed in the (X,Z) plane as specified in the specimen\
-  \ frame.\n[Figure 10](onde_component.md) illustrates the CAD frame positioning to\
-  \ the component frame for a planar component.\n\n![Convention for the positioning\
-  \ of the visualization CAD in a planar component](../images/media/viz_cad_planar.png\
-  \ \"Figure 10\")\n\n*[Figure 10](onde_component.md): Convention for the positioning\
-  \ of the visualization CAD in a planar component*\n\n[Figure 11](onde_component.md)\
-  \ illustrates the CAD frame positioning according to the component frame for a cylinder\
-  \ specimen. The outer\ndiameter corresponds to the distance between the top left\
-  \ hand corner of the dxf profile and the origin of the component\nframe.\n\n![Convention\
-  \ for the positioning of the visualization CAD in a cylindrical component](../images/media/viz_cad_cylindrical.png\
-  \ \"Figure 11\")\n\n*[Figure 11](onde_component.md): Convention for the positioning\
-  \ of the visualization CAD in a cylindrical component*"
+description: |-
+    ### Component
+  
+    **Velocities**
+  
+    The two values of the VELOCITIES array indicate the inspected component longitudinal and shear wave velocity
+    respectively. If both velocities (Longitudinal and Shear) are not available, the missing one should be replaced by a
+    NaN).
+  
+    This version of the format handles only isotropic materials.
+  
+    **Shape and dimensions**
+  
+    The geometric shape of the inspected component is defined by the subclass of ONDE_COMPONENT. It can be 
+     one of the following: "ONDE_PLANE","ONDE_CYLINDER",
+    "ONDE_2DCAD", "ONDE_3DCAD", "ONDE_WELD". While the format is quite generic by handling CAD files, parametric description is 
+    available for plane, cylindrical and weld specimens. Other parameterized shapes can be added in future versions.
+  
+    For plane components, the dimensions are give by PLATE_DIMENSIONS, with a triplet for length, width and height.
+  
+    For cylindrical components, the dimensions are given by CYLINDER_DIMENSIONS, with a triplet for outer diameter,
+    thickness, and length.
+  
+    /* TODO : update with weld descriptions */
+  
+    For 2D extruded components and welds, extrusion is provided by EXTRUSION_TYPE (plane or sylindrical) and EXTRUSION_DIMENSION for
+    the length for plane extrusion, the diameter for cylindrical ones.
+  
+    The CAD field can contain a STEP or STL file for 3D CADs, a dxf file for 2D CADs.
+  
+    ```mermaid
+    classDiagram
+      component <|-- plane
+      component <|-- cylinder
+      component <|-- 2d_cad
+      component <|-- 3d_cad
+      component <|-- weld
+    ```
+  
+    **Visualisation CAD**
+  
+    VISUALISATION_CAD contains a DXF or STL file for the component visualization. When using a dxf file, the profile will be
+    extruded linearly or cylindrically according to the component type.
+  
+    **Transformations**
+  
+    The global coordinate system is distinct from the specimen coordinate system : for example, 2D and 3D CAD coordinates
+    are defined in the specimen frame and repositioned in the global coordinate system with the transformation defined in
+    COMPONENT_FRAME ([see paragraph 1.6](index.md#definition-of-frames)).
+  
+    **Visualization CAD**
+  
+    When a dxf is provided for the Visualization CAD, the extrusion of the CAD is implied from the specimen shape : it is of
+    linear nature if the specimen is a plate or a 2D CAD with linear extrusion, it is cylindrical if the specimen is a
+    cylinder or a 2D CAD with cylindrical extrusion. A typical use case for this feature is the ability to superimpose a
+    weld profile to a plate or cylindrical specimen in order to facilitate the interpretation of the indications.
+  
+    The CAD profiles that are used for visualization are expressed in the (X,Z) plane as specified in the specimen frame.
+    [Figure 10](onde_component.md) illustrates the CAD frame positioning to the component frame for a planar component.
+  
+    ![Convention for the positioning of the visualization CAD in a planar component](../images/media/viz_cad_planar.png "Figure 10")
+  
+    *[Figure 10](onde_component.md): Convention for the positioning of the visualization CAD in a planar component*
+  
+    [Figure 11](onde_component.md) illustrates the CAD frame positioning according to the component frame for a cylinder specimen. The outer
+    diameter corresponds to the distance between the top left hand corner of the dxf profile and the origin of the component
+    frame.
+  
+    ![Convention for the positioning of the visualization CAD in a cylindrical component](../images/media/viz_cad_cylindrical.png "Figure 11")
+  
+    *[Figure 11](onde_component.md): Convention for the positioning of the visualization CAD in a cylindrical component*
 fields:
   LABEL:
     full_name: ONDE:LABEL

--- a/class_definitions/onde_component.yaml
+++ b/class_definitions/onde_component.yaml
@@ -2,34 +2,34 @@ onde_class: ONDE_COMPONENT
 inherits: []
 description: |-
     ### Component
-  
-    **Velocities**
-  
+
+    #### Velocities
+
     The two values of the VELOCITIES array indicate the inspected component longitudinal and shear wave velocity
     respectively. If both velocities (Longitudinal and Shear) are not available, the missing one should be replaced by a
     NaN).
-  
+
     This version of the format handles only isotropic materials.
-  
-    **Shape and dimensions**
-  
-    The geometric shape of the inspected component is defined by the subclass of ONDE_COMPONENT. It can be 
+
+    #### Shape and dimensions
+
+    The geometric shape of the inspected component is defined by the subclass of ONDE_COMPONENT. It can be
      one of the following: "ONDE_PLANE","ONDE_CYLINDER",
-    "ONDE_2DCAD", "ONDE_3DCAD", "ONDE_WELD". While the format is quite generic by handling CAD files, parametric description is 
+    "ONDE_2DCAD", "ONDE_3DCAD", "ONDE_WELD". While the format is quite generic by handling CAD files, parametric description is
     available for plane, cylindrical and weld specimens. Other parameterized shapes can be added in future versions.
-  
+
     For plane components, the dimensions are give by PLATE_DIMENSIONS, with a triplet for length, width and height.
-  
+
     For cylindrical components, the dimensions are given by CYLINDER_DIMENSIONS, with a triplet for outer diameter,
     thickness, and length.
-  
+
     /* TODO : update with weld descriptions */
-  
+
     For 2D extruded components and welds, extrusion is provided by EXTRUSION_TYPE (plane or sylindrical) and EXTRUSION_DIMENSION for
     the length for plane extrusion, the diameter for cylindrical ones.
-  
+
     The CAD field can contain a STEP or STL file for 3D CADs, a dxf file for 2D CADs.
-  
+
     ```mermaid
     classDiagram
       component <|-- plane
@@ -38,38 +38,38 @@ description: |-
       component <|-- 3d_cad
       component <|-- weld
     ```
-  
-    **Visualisation CAD**
-  
+
+    #### Visualisation CAD
+
     VISUALISATION_CAD contains a DXF or STL file for the component visualization. When using a dxf file, the profile will be
     extruded linearly or cylindrically according to the component type.
-  
-    **Transformations**
-  
+
+    #### Transformations
+
     The global coordinate system is distinct from the specimen coordinate system : for example, 2D and 3D CAD coordinates
     are defined in the specimen frame and repositioned in the global coordinate system with the transformation defined in
     COMPONENT_FRAME ([see paragraph 1.6](index.md#definition-of-frames)).
-  
-    **Visualization CAD**
-  
+
+    #### Visualization CAD
+
     When a dxf is provided for the Visualization CAD, the extrusion of the CAD is implied from the specimen shape : it is of
     linear nature if the specimen is a plate or a 2D CAD with linear extrusion, it is cylindrical if the specimen is a
     cylinder or a 2D CAD with cylindrical extrusion. A typical use case for this feature is the ability to superimpose a
     weld profile to a plate or cylindrical specimen in order to facilitate the interpretation of the indications.
-  
+
     The CAD profiles that are used for visualization are expressed in the (X,Z) plane as specified in the specimen frame.
     [Figure 10](onde_component.md) illustrates the CAD frame positioning to the component frame for a planar component.
-  
+
     ![Convention for the positioning of the visualization CAD in a planar component](../images/media/viz_cad_planar.png "Figure 10")
-  
+
     *[Figure 10](onde_component.md): Convention for the positioning of the visualization CAD in a planar component*
-  
+
     [Figure 11](onde_component.md) illustrates the CAD frame positioning according to the component frame for a cylinder specimen. The outer
     diameter corresponds to the distance between the top left hand corner of the dxf profile and the origin of the component
     frame.
-  
+
     ![Convention for the positioning of the visualization CAD in a cylindrical component](../images/media/viz_cad_cylindrical.png "Figure 11")
-  
+
     *[Figure 11](onde_component.md): Convention for the positioning of the visualization CAD in a cylindrical component*
 fields:
   LABEL:

--- a/class_definitions/onde_cylinder.yaml
+++ b/class_definitions/onde_cylinder.yaml
@@ -1,21 +1,15 @@
 onde_class: ONDE_CYLINDER
 inherits:
 - ONDE_COMPONENT
-description: '**Conventions for cylindrical components**
-
-
-  In the cylindrical coordinate system, the x direction is the one corresponding to
-  the cylinder axis (see [Figure 7](onde_cylinder.md)). The
-
-  dimensions are given by CYLINDER_DIMENSIONS, with a triplet for outer diameter,
-  thickness, and length .
-
-
-  ![Trajectory cylindrical coordinate system convention](../images/media/trajectory_cylindrical_coords.png
-  "Figure 7")
-
-
-  *[Figure 7](onde_cylinder.md): Trajectory cylindrical coordinate system convention*'
+description: |-
+    **Conventions for cylindrical components**
+  
+    In the cylindrical coordinate system, the x direction is the one corresponding to the cylinder axis (see [Figure 7](onde_cylinder.md)). The
+    dimensions are given by CYLINDER_DIMENSIONS, with a triplet for outer diameter, thickness, and length .
+  
+    ![Trajectory cylindrical coordinate system convention](../images/media/trajectory_cylindrical_coords.png "Figure 7")
+  
+    *[Figure 7](onde_cylinder.md): Trajectory cylindrical coordinate system convention*
 fields:
   DIMENSIONS:
     full_name: ONDE_CYLINDER:DIMENSIONS

--- a/class_definitions/onde_cylinder.yaml
+++ b/class_definitions/onde_cylinder.yaml
@@ -2,13 +2,13 @@ onde_class: ONDE_CYLINDER
 inherits:
 - ONDE_COMPONENT
 description: |-
-    **Conventions for cylindrical components**
-  
+    #### Conventions for cylindrical components
+
     In the cylindrical coordinate system, the x direction is the one corresponding to the cylinder axis (see [Figure 7](onde_cylinder.md)). The
     dimensions are given by CYLINDER_DIMENSIONS, with a triplet for outer diameter, thickness, and length .
-  
+
     ![Trajectory cylindrical coordinate system convention](../images/media/trajectory_cylindrical_coords.png "Figure 7")
-  
+
     *[Figure 7](onde_cylinder.md): Trajectory cylindrical coordinate system convention*
 fields:
   DIMENSIONS:

--- a/class_definitions/onde_dataset.yaml
+++ b/class_definitions/onde_dataset.yaml
@@ -11,7 +11,7 @@ description: |
   ### Notes on groups
 
     The following links provide explanatory notes for the ONDE groups that are described in the [YAML schemas](https://github.com/COFREND/ONDE-format/tree/main/class_definitions).
-    
+
   [Ascan datasets](onde_dataset_ut_ascan.md)
 
   [Tscan datasets](onde_dataset_ut_tscan.md)

--- a/class_definitions/onde_dataset_ut_ascan.yaml
+++ b/class_definitions/onde_dataset_ut_ascan.yaml
@@ -3,17 +3,12 @@ inherits:
 - ONDE_DATASET_UT
 description: '### Ascan datasets
 
-
   Ascan datasets are the entry points for the description of data that is stored as
-  time signals. The MFMC equivalent is ''
-
-  SEQUENCE'', and both names are allowed to ensure compatibility.
-
+  time signals. 
 
   To allow continuity with existing HDF5 formats, the DATA field can be either a HDF5
-  dataset or a reference to a
-
-  dataset located in another part of the HDF5 structure.'
+  dataset or a reference to a dataset located in another part of the HDF5 structure.'
+  
 fields:
   DATA:
     full_name: ONDE_DATASET:DATA
@@ -23,4 +18,4 @@ fields:
     description: Data can be either an array or a reference to an array. Omitting
       this field is possible, in the event when Tscan or Cscan data is recorded but
       the underlying Ascan data is not.
-    dimensions: 1 or [N_DF<m>,N_Ascan<m>,Ntime<m>]
+    dimensions: 1 or [N_U<m>,N_V<m>,N_Ascan<m>,Ntime<m>]

--- a/class_definitions/onde_dataset_ut_ascan.yaml
+++ b/class_definitions/onde_dataset_ut_ascan.yaml
@@ -1,19 +1,14 @@
 onde_class: ONDE_DATASET_UT_ASCAN
 inherits:
 - ONDE_DATASET_UT
-description: '### Ascan datasets
-
-
-  Ascan datasets are the entry points for the description of data that is stored as
-  time signals. The MFMC equivalent is ''
-
-  SEQUENCE'', and both names are allowed to ensure compatibility.
-
-
-  To allow continuity with existing HDF5 formats, the DATA field can be either a HDF5
-  dataset or a reference to a
-
-  dataset located in another part of the HDF5 structure.'
+description: |-
+    ### Ascan datasets
+  
+    Ascan datasets are the entry points for the description of data that is stored as time signals. The MFMC equivalent is '
+    SEQUENCE', and both names are allowed to ensure compatibility.
+  
+    To allow continuity with existing HDF5 formats, the DATA field can be either a HDF5 dataset or a reference to a
+    dataset located in another part of the HDF5 structure.
 fields:
   DATA:
     full_name: ONDE_DATASET:DATA

--- a/class_definitions/onde_dataset_ut_ascan.yaml
+++ b/class_definitions/onde_dataset_ut_ascan.yaml
@@ -3,10 +3,10 @@ inherits:
 - ONDE_DATASET_UT
 description: |-
     ### Ascan datasets
-  
-    Ascan datasets are the entry points for the description of data that is stored as time signals. The MFMC equivalent is '
-    SEQUENCE', and both names are allowed to ensure compatibility.
-  
+
+    Ascan datasets are the entry points for the description of data that is stored as time signals. The MFMC equivalent is
+    'SEQUENCE', and both names are allowed to ensure compatibility.
+
     To allow continuity with existing HDF5 formats, the DATA field can be either a HDF5 dataset or a reference to a
     dataset located in another part of the HDF5 structure.
 fields:

--- a/class_definitions/onde_dataset_ut_cscan.yaml
+++ b/class_definitions/onde_dataset_ut_cscan.yaml
@@ -1,39 +1,66 @@
 onde_class: ONDE_DATASET_UT_CSCAN
 inherits:
 - ONDE_DATASET_UT
-description: "### CScan datasets and gates\n\n**CScan data and peaks**\n\nWhile this\
-  \ Cscan dataset is mostly meant for the storage of peak-like data (amplitude, time\
-  \ of flight, etc...) it is\nmore generic and can accommodate different values.\n\
-  \nDATA contains a vector of references to datasets containing scalar raw data. The\
-  \ size of the data can be either\nN_DF\\<m\\> x N_Ascan\\<m\\> arrays (for data\
-  \ resulting from analysis of signals or N_DF\\<m\\> arrays for encoder data or\n\
-  data\nresulting from Tscan or monoelement scans.\n\n**Data description**\n\nThe\
-  \ DATATYPE field contains a name defining the nature of the data- the name can be\
-  \ either custom (MY_MATERIAL_PROPERTY\nfor instance) or a standardized name: THICKNESS,\
-  \ TIME_OF_FLIGHT, DEPTH, AMAX.\n\n**Data numbering**\n\nTo be efficient for relatively\
-  \ small amounts of data, as opposed to other blocks, the Cscan block allows for\n\
-  the handling of several data inside the block. The DATA, DATA_TYPE vectors must\
-  \ have the same length and be ordered\ncoherently.\n\n**Data positioning**\n\nThe\
-  \ Cscan data must be positioned through a trajectory block which is of grid type\
-  \ and is referenced by the CSCAN_GRID attribute.\n\n**Underlying raw data**\n\n\
-  UNDERLYING_DATA is used to point to the dataset that corresponds to the originating\
-  \ raw data. LINKED_DATASET_REFERENCE\ngives the correspondence between the scalar\
-  \ data and the originating scan. For a A-Scan, the correspondence to the scan\n\
-  is expressed in terms of (dataframe, law). For a 2D Tscan, it will be (dataframe,\
-  \ column), for a 3D Tscan, it will be (\ndataframe, plane, column).\n\n**Gates**\n\
-  \nThe gates are stored as a separate group of type ONDE_UT_GATE. The gates are referenced\
-  \ in the ONDE_DATASET_UT_CSCAN group via the \nONDE_DATASET_UT_CSCAN:GATES field.\n\
-  The gates used for the acquisition are defined through five parameters.\\\nGATE_START\
-  \ and GATE_WIDTH define the time window and GATE_THRESHOLD defines the threshold\
-  \ that was used to trigger the\nstorage of the data. GATE_DETECTION defines the\
-  \ type of triggering event that was used to define the gate. \nGATE_POLARITY defines\
-  \ the mode that was used for the detection (absolute, positive or negative).\n\n\
-  The following figure defines the modes that can be used for detection. The numbers\
-  \ on the figure correspond to the different triggering events. The correspondence\
-  \ between these figures and the values allowed for GATE_DETECTION is the following\
-  \ :  \n1 - FIRST_FLANK\n2 - FIRST_PEAK\n3 - MAX_FLANK\n4 - MAX_PEAK\n5 - LAST_PEAK\n\
-  6 - LAST_FLANK\n![Detection modes for UT gates](../images/media/gate_detection.png)\n\
-  \n"
+description: '### CScan datasets and gates
+
+#### CScan data and peaks
+
+While this Cscan dataset is mostly meant for the storage of peak-like data (amplitude, time
+of flight, etc...) it is more generic and can accommodate different values.
+DATA contains a vector of references to datasets containing scalar raw data. The
+size of the data can be either N_U<m> x N_V<m> x N_Ascan<m> arrays (for data
+resulting from analysis of signals or N_U<m>xN_V<m> arrays for encoder data or
+  data resulting from Tscan or monoelement scans.
+
+#### Data description
+
+  The DATATYPE field contains a name defining the nature of the data
+  - the name can be either custom (MY_MATERIAL_PROPERTY\nfor instance) or a standardized name: THICKNESS,
+   TIME_OF_FLIGHT, DEPTH, AMAX.
+
+#### Data numbering
+
+   To be efficient for relatively
+   small amounts of data, as opposed to other blocks, the Cscan block allows for
+  the handling of several data inside the block. The DATA, DATA_TYPE vectors must
+   have the same length and be ordered\ncoherently.
+   
+#### Data positioning
+
+   The Cscan data must be positioned through a trajectory block which is of grid type
+   and is referenced by the CSCAN_GRID attribute.
+
+#### Underlying raw data
+
+  UNDERLYING_DATA is used to point to the dataset that corresponds to the originating
+   raw data. LINKED_DATASET_REFERENCE gives the correspondence between the scalar
+   data and the originating scan. For a A-Scan, the correspondence to the scan
+  is expressed in terms of (dataframe, law). For a 2D Tscan, it will be (dataframe,
+  column), for a 3D Tscan, it will be (\ndataframe, plane, column).
+   
+#### Gates
+
+  The gates are stored as a separate group of type ONDE_UT_GATE. The gates are referenced
+   in the ONDE_DATASET_UT_CSCAN group via the ONDE_DATASET_UT_CSCAN:GATES field.
+  The gates used for the acquisition are defined through five parameters. GATE_START
+  and GATE_WIDTH define the time window and GATE_THRESHOLD defines the threshold
+  that was used to trigger the\nstorage of the data. GATE_DETECTION defines the
+  type of triggering event that was used to define the gate. GATE_POLARITY defines
+  the mode that was used for the detection (absolute, positive or negative).
+  The following figure defines the modes that can be used for detection. The numbers
+  on the figure correspond to the different triggering events. The correspondence
+  between these figures and the values allowed for GATE_DETECTION is the following
+  :  
+
+  1 - FIRST_FLANK
+  2 - FIRST_PEAK
+  3 - MAX_FLANK
+  4 - MAX_PEAK
+  5 - LAST_PEAK
+  6 - LAST_FLANK
+  
+  ![Detection modes for UT gates](../images/media/gate_detection.png)'
+
 fields:
   DATA:
     full_name: ONDE_DATASET:DATA
@@ -68,7 +95,7 @@ fields:
       For a A-Scan, the scan is expressed in terms of (dataframe, law). For a 2D Tscan,
       it will be (dataframe, column), for a 3D Tscan, it will be (dataframe, plane,
       column)
-    dimensions: '[N_DF<m>,2] or [N_DF<m>,3]'
+    dimensions: '[N_U<m>,N_V<m>,2] or [N_U<m>,N_V<m>,3]'
   CSCAN_GRID:
     full_name: ONDE_DATASET_UT_CSCAN:CSCAN_GRID
     required: true

--- a/class_definitions/onde_dataset_ut_cscan.yaml
+++ b/class_definitions/onde_dataset_ut_cscan.yaml
@@ -1,39 +1,59 @@
 onde_class: ONDE_DATASET_UT_CSCAN
 inherits:
 - ONDE_DATASET_UT
-description: "### CScan datasets and gates\n\n**CScan data and peaks**\n\nWhile this\
-  \ Cscan dataset is mostly meant for the storage of peak-like data (amplitude, time\
-  \ of flight, etc...) it is\nmore generic and can accommodate different values.\n\
-  \nDATA contains a vector of references to datasets containing scalar raw data. The\
-  \ size of the data can be either\nN_DF\\<m\\> x N_Ascan\\<m\\> arrays (for data\
-  \ resulting from analysis of signals or N_DF\\<m\\> arrays for encoder data or\n\
-  data\nresulting from Tscan or monoelement scans.\n\n**Data description**\n\nThe\
-  \ DATATYPE field contains a name defining the nature of the data- the name can be\
-  \ either custom (MY_MATERIAL_PROPERTY\nfor instance) or a standardized name: THICKNESS,\
-  \ TIME_OF_FLIGHT, DEPTH, AMAX.\n\n**Data numbering**\n\nTo be efficient for relatively\
-  \ small amounts of data, as opposed to other blocks, the Cscan block allows for\n\
-  the handling of several data inside the block. The DATA, DATA_TYPE vectors must\
-  \ have the same length and be ordered\ncoherently.\n\n**Data positioning**\n\nThe\
-  \ Cscan data must be positioned through a trajectory block which is of grid type\
-  \ and is referenced by the CSCAN_GRID attribute.\n\n**Underlying raw data**\n\n\
-  UNDERLYING_DATA is used to point to the dataset that corresponds to the originating\
-  \ raw data. LINKED_DATASET_REFERENCE\ngives the correspondence between the scalar\
-  \ data and the originating scan. For a A-Scan, the correspondence to the scan\n\
-  is expressed in terms of (dataframe, law). For a 2D Tscan, it will be (dataframe,\
-  \ column), for a 3D Tscan, it will be (\ndataframe, plane, column).\n\n**Gates**\n\
-  \nThe gates are stored as a separate group of type ONDE_UT_GATE. The gates are referenced\
-  \ in the ONDE_DATASET_UT_CSCAN group via the \nONDE_DATASET_UT_CSCAN:GATES field.\n\
-  The gates used for the acquisition are defined through five parameters.\\\nGATE_START\
-  \ and GATE_WIDTH define the time window and GATE_THRESHOLD defines the threshold\
-  \ that was used to trigger the\nstorage of the data. GATE_DETECTION defines the\
-  \ type of triggering event that was used to define the gate. \nGATE_POLARITY defines\
-  \ the mode that was used for the detection (absolute, positive or negative).\n\n\
-  The following figure defines the modes that can be used for detection. The numbers\
-  \ on the figure correspond to the different triggering events. The correspondence\
-  \ between these figures and the values allowed for GATE_DETECTION is the following\
-  \ :  \n1 - FIRST_FLANK\n2 - FIRST_PEAK\n3 - MAX_FLANK\n4 - MAX_PEAK\n5 - LAST_PEAK\n\
-  6 - LAST_FLANK\n![Detection modes for UT gates](../images/media/gate_detection.png)\n\
-  \n"
+description: |+
+    ### CScan datasets and gates
+  
+    **CScan data and peaks**
+  
+    While this Cscan dataset is mostly meant for the storage of peak-like data (amplitude, time of flight, etc...) it is
+    more generic and can accommodate different values.
+  
+    DATA contains a vector of references to datasets containing scalar raw data. The size of the data can be either
+    N_DF\<m\> x N_Ascan\<m\> arrays (for data resulting from analysis of signals or N_DF\<m\> arrays for encoder data or
+    data
+    resulting from Tscan or monoelement scans.
+  
+    **Data description**
+  
+    The DATATYPE field contains a name defining the nature of the data- the name can be either custom (MY_MATERIAL_PROPERTY
+    for instance) or a standardized name: THICKNESS, TIME_OF_FLIGHT, DEPTH, AMAX.
+  
+    **Data numbering**
+  
+    To be efficient for relatively small amounts of data, as opposed to other blocks, the Cscan block allows for
+    the handling of several data inside the block. The DATA, DATA_TYPE vectors must have the same length and be ordered
+    coherently.
+  
+    **Data positioning**
+  
+    The Cscan data must be positioned through a trajectory block which is of grid type and is referenced by the CSCAN_GRID attribute.
+  
+    **Underlying raw data**
+  
+    UNDERLYING_DATA is used to point to the dataset that corresponds to the originating raw data. LINKED_DATASET_REFERENCE
+    gives the correspondence between the scalar data and the originating scan. For a A-Scan, the correspondence to the scan
+    is expressed in terms of (dataframe, law). For a 2D Tscan, it will be (dataframe, column), for a 3D Tscan, it will be (
+    dataframe, plane, column).
+  
+    **Gates**
+  
+    The gates are stored as a separate group of type ONDE_UT_GATE. The gates are referenced in the ONDE_DATASET_UT_CSCAN group via the 
+    ONDE_DATASET_UT_CSCAN:GATES field.
+    The gates used for the acquisition are defined through five parameters.\
+    GATE_START and GATE_WIDTH define the time window and GATE_THRESHOLD defines the threshold that was used to trigger the
+    storage of the data. GATE_DETECTION defines the type of triggering event that was used to define the gate. 
+    GATE_POLARITY defines the mode that was used for the detection (absolute, positive or negative).
+  
+    The following figure defines the modes that can be used for detection. The numbers on the figure correspond to the different triggering events. The correspondence between these figures and the values allowed for GATE_DETECTION is the following :  
+    1 - FIRST_FLANK
+    2 - FIRST_PEAK
+    3 - MAX_FLANK
+    4 - MAX_PEAK
+    5 - LAST_PEAK
+    6 - LAST_FLANK
+    ![Detection modes for UT gates](../images/media/gate_detection.png)
+  
 fields:
   DATA:
     full_name: ONDE_DATASET:DATA

--- a/class_definitions/onde_dataset_ut_cscan.yaml
+++ b/class_definitions/onde_dataset_ut_cscan.yaml
@@ -3,49 +3,49 @@ inherits:
 - ONDE_DATASET_UT
 description: |+
     ### CScan datasets and gates
-  
-    **CScan data and peaks**
-  
+
+    #### CScan data and peaks
+
     While this Cscan dataset is mostly meant for the storage of peak-like data (amplitude, time of flight, etc...) it is
     more generic and can accommodate different values.
-  
+
     DATA contains a vector of references to datasets containing scalar raw data. The size of the data can be either
     N_DF\<m\> x N_Ascan\<m\> arrays (for data resulting from analysis of signals or N_DF\<m\> arrays for encoder data or
     data
     resulting from Tscan or monoelement scans.
-  
-    **Data description**
-  
+
+    #### Data description
+
     The DATATYPE field contains a name defining the nature of the data- the name can be either custom (MY_MATERIAL_PROPERTY
     for instance) or a standardized name: THICKNESS, TIME_OF_FLIGHT, DEPTH, AMAX.
-  
-    **Data numbering**
-  
+
+    #### Data numbering
+
     To be efficient for relatively small amounts of data, as opposed to other blocks, the Cscan block allows for
     the handling of several data inside the block. The DATA, DATA_TYPE vectors must have the same length and be ordered
     coherently.
-  
-    **Data positioning**
-  
+
+    #### Data positioning
+
     The Cscan data must be positioned through a trajectory block which is of grid type and is referenced by the CSCAN_GRID attribute.
-  
-    **Underlying raw data**
-  
+
+    #### Underlying raw data
+
     UNDERLYING_DATA is used to point to the dataset that corresponds to the originating raw data. LINKED_DATASET_REFERENCE
     gives the correspondence between the scalar data and the originating scan. For a A-Scan, the correspondence to the scan
     is expressed in terms of (dataframe, law). For a 2D Tscan, it will be (dataframe, column), for a 3D Tscan, it will be (
     dataframe, plane, column).
-  
-    **Gates**
-  
-    The gates are stored as a separate group of type ONDE_UT_GATE. The gates are referenced in the ONDE_DATASET_UT_CSCAN group via the 
+
+    #### Gates
+
+    The gates are stored as a separate group of type ONDE_UT_GATE. The gates are referenced in the ONDE_DATASET_UT_CSCAN group via the
     ONDE_DATASET_UT_CSCAN:GATES field.
     The gates used for the acquisition are defined through five parameters.\
     GATE_START and GATE_WIDTH define the time window and GATE_THRESHOLD defines the threshold that was used to trigger the
-    storage of the data. GATE_DETECTION defines the type of triggering event that was used to define the gate. 
+    storage of the data. GATE_DETECTION defines the type of triggering event that was used to define the gate.
     GATE_POLARITY defines the mode that was used for the detection (absolute, positive or negative).
-  
-    The following figure defines the modes that can be used for detection. The numbers on the figure correspond to the different triggering events. The correspondence between these figures and the values allowed for GATE_DETECTION is the following :  
+
+    The following figure defines the modes that can be used for detection. The numbers on the figure correspond to the different triggering events. The correspondence between these figures and the values allowed for GATE_DETECTION is the following :
     1 - FIRST_FLANK
     2 - FIRST_PEAK
     3 - MAX_FLANK
@@ -53,7 +53,7 @@ description: |+
     5 - LAST_PEAK
     6 - LAST_FLANK
     ![Detection modes for UT gates](../images/media/gate_detection.png)
-  
+
 fields:
   DATA:
     full_name: ONDE_DATASET:DATA

--- a/class_definitions/onde_dataset_ut_tscan.yaml
+++ b/class_definitions/onde_dataset_ut_tscan.yaml
@@ -1,30 +1,43 @@
 onde_class: ONDE_DATASET_UT_TSCAN
 inherits:
 - ONDE_DATASET_UT
-description: "### Tscan datasets\n\n**General**\n\nEven though the name (Tscans coming\
-  \ from TFM Scans) implicitly refers to the TFM reconstruction images, the block\
-  \ can\napply to any reconstruction method producing data on a rectangular/parallelepiped\
-  \ grid that moves with the sensor (be it\nobtained by TFM, Adaptive TFM, PWI, Adaptive\
-  \ PWI, frequency reconstruction, or any variant of these methods)\n\n**Underlying\
-  \ data**\nThe ELEMENTARY_CHANNELS_DATASET points to the Ascan dataset that was used\
-  \ to create the reconstruction. \nIt is a mandatory attribute (the Ascan dataset\
-  \ structure can contain no data if the elementary channels were not recorded).\n\
-  \n**3D Zones**\n\nThe format allows for the description of 3D zones. Taking into\
-  \ account the dimension related to positions, this implies\nthat the dimension of\
-  \ the data array depends on the zone dimension (3D array for 2D zones 4D array for\
-  \ 3D zones),\n\n**Zone dimension and position**\n\nThe zone physical dimension is\
-  \ given by the ZONE_DIMENSION field, (DX,DY,DZ) being the physical dimensions of\
-  \ the zone,\na zero or a NaN for one of the dimension implies a 2D zone.\n\nZONE_SIZE\
-  \ is a triplet which gives the number of pixels of the zone for each dimension (NX,NY,NZ).\n\
-  \nThe zone position is given by ZONE_FRAME and is expressed relatively to the trajectory\
-  \ of the probe which is given in the associated GEOMETRIC_SETUP probe list. The\
-  \ index of the probe in this list is given by the REFERENCE_PROBE_INDEX attribute\
-  \ (defaults to 0).\n\n![Example of TFM zone positioning](../images/media/tfm_zone_positioning.png\
-  \ \"Figure 5\")\n\n*[Figure 5](onde_dataset_ut_tscan.md): Example of TFM zone positioning*\n\
-  \nIn the example displayed in [Figure 5](onde_dataset_ut_tscan.md), the trajectory\
-  \ frame is located at the index point and the zone is positioned\naccordingly.\n\
-  \n**Pixel ordering**\n\nThe pixels are stored in the (X,Y,Z) order (X being the\
-  \ outer loop, Z the inner loop in the array)"
+description: |-
+    ### Tscan datasets
+  
+    **General**
+  
+    Even though the name (Tscans coming from TFM Scans) implicitly refers to the TFM reconstruction images, the block can
+    apply to any reconstruction method producing data on a rectangular/parallelepiped grid that moves with the sensor (be it
+    obtained by TFM, Adaptive TFM, PWI, Adaptive PWI, frequency reconstruction, or any variant of these methods)
+  
+    **Underlying data**
+    The ELEMENTARY_CHANNELS_DATASET points to the Ascan dataset that was used to create the reconstruction. 
+    It is a mandatory attribute (the Ascan dataset structure can contain no data if the elementary channels were not recorded).
+  
+    **3D Zones**
+  
+    The format allows for the description of 3D zones. Taking into account the dimension related to positions, this implies
+    that the dimension of the data array depends on the zone dimension (3D array for 2D zones 4D array for 3D zones),
+  
+    **Zone dimension and position**
+  
+    The zone physical dimension is given by the ZONE_DIMENSION field, (DX,DY,DZ) being the physical dimensions of the zone,
+    a zero or a NaN for one of the dimension implies a 2D zone.
+  
+    ZONE_SIZE is a triplet which gives the number of pixels of the zone for each dimension (NX,NY,NZ).
+  
+    The zone position is given by ZONE_FRAME and is expressed relatively to the trajectory of the probe which is given in the associated GEOMETRIC_SETUP probe list. The index of the probe in this list is given by the REFERENCE_PROBE_INDEX attribute (defaults to 0).
+  
+    ![Example of TFM zone positioning](../images/media/tfm_zone_positioning.png "Figure 5")
+  
+    *[Figure 5](onde_dataset_ut_tscan.md): Example of TFM zone positioning*
+  
+    In the example displayed in [Figure 5](onde_dataset_ut_tscan.md), the trajectory frame is located at the index point and the zone is positioned
+    accordingly.
+  
+    **Pixel ordering**
+  
+    The pixels are stored in the (X,Y,Z) order (X being the outer loop, Z the inner loop in the array)
 fields:
   DATA:
     full_name: ONDE_DATASET:DATA

--- a/class_definitions/onde_dataset_ut_tscan.yaml
+++ b/class_definitions/onde_dataset_ut_tscan.yaml
@@ -1,30 +1,48 @@
 onde_class: ONDE_DATASET_UT_TSCAN
 inherits:
 - ONDE_DATASET_UT
-description: "### Tscan datasets\n\n**General**\n\nEven though the name (Tscans coming\
-  \ from TFM Scans) implicitly refers to the TFM reconstruction images, the block\
-  \ can\napply to any reconstruction method producing data on a rectangular/parallelepiped\
-  \ grid that moves with the sensor (be it\nobtained by TFM, Adaptive TFM, PWI, Adaptive\
-  \ PWI, frequency reconstruction, or any variant of these methods)\n\n**Underlying\
-  \ data**\nThe ELEMENTARY_CHANNELS_DATASET points to the Ascan dataset that was used\
-  \ to create the reconstruction. \nIt is a mandatory attribute (the Ascan dataset\
-  \ structure can contain no data if the elementary channels were not recorded).\n\
-  \n**3D Zones**\n\nThe format allows for the description of 3D zones. Taking into\
-  \ account the dimension related to positions, this implies\nthat the dimension of\
-  \ the data array depends on the zone dimension (3D array for 2D zones 4D array for\
-  \ 3D zones),\n\n**Zone dimension and position**\n\nThe zone physical dimension is\
-  \ given by the ZONE_DIMENSION field, (DX,DY,DZ) being the physical dimensions of\
-  \ the zone,\na zero or a NaN for one of the dimension implies a 2D zone.\n\nZONE_SIZE\
-  \ is a triplet which gives the number of pixels of the zone for each dimension (NX,NY,NZ).\n\
-  \nThe zone position is given by ZONE_FRAME and is expressed relatively to the trajectory\
-  \ of the probe which is given in the associated GEOMETRIC_SETUP probe list. The\
-  \ index of the probe in this list is given by the REFERENCE_PROBE_INDEX attribute\
-  \ (defaults to 0).\n\n![Example of TFM zone positioning](../images/media/tfm_zone_positioning.png\
-  \ \"Figure 5\")\n\n*[Figure 5](onde_dataset_ut_tscan.md): Example of TFM zone positioning*\n\
-  \nIn the example displayed in [Figure 5](onde_dataset_ut_tscan.md), the trajectory\
-  \ frame is located at the index point and the zone is positioned\naccordingly.\n\
-  \n**Pixel ordering**\n\nThe pixels are stored in the (X,Y,Z) order (X being the\
-  \ outer loop, Z the inner loop in the array)"
+description: '### Tscan datasets
+
+#### General
+
+Even though the name (Tscans coming from TFM Scans) implicitly refers to the TFM reconstruction images, the block
+can apply to any reconstruction method producing data on a rectangular/parallelepiped
+grid that moves with the sensor (be it obtained by TFM, Adaptive TFM, PWI, Adaptive
+PWI, frequency reconstruction, or any variant of these methods).
+
+#### Underlying data
+
+The ELEMENTARY_CHANNELS_DATASET points to the Ascan dataset that was used
+to create the reconstruction. It is a mandatory attribute (the Ascan dataset
+structure can contain no data if the elementary channels were not recorded).
+
+#### 3D Zones
+
+The format allows for the description of 3D zones. Taking into
+account the dimension related to positions, this implies\nthat the dimension of
+the data array depends on the zone dimension (3D array for 2D zones 4D array for
+3D zones),\n\n**Zone dimension and position**\n\nThe zone physical dimension is
+given by the ZONE_DIMENSION field, (DX,DY,DZ) being the physical dimensions of
+the zone,\na zero or a NaN for one of the dimension implies a 2D zone.
+ZONE_SIZE is a triplet which gives the number of pixels of the zone for each dimension (NX,NY,NZ).
+
+The zone position is given by ZONE_FRAME and is expressed relatively to the trajectory
+of the probe which is given in the associated GEOMETRIC_SETUP probe list. The
+index of the probe in this list is given by the REFERENCE_PROBE_INDEX attribute
+(defaults to 0).
+
+![Example of TFM zone positioning](../images/media/tfm_zone_positioning.png\
+  \ \"Figure 5\")
+  
+  *[Figure 5](onde_dataset_ut_tscan.md): Example of TFM zone positioning*
+
+  In the example displayed in [Figure 5](onde_dataset_ut_tscan.md), the trajectory
+  frame is located at the index point and the zone is positioned\naccordingly.
+  
+  #### Pixel ordering
+
+  The pixels are stored in the (X,Y,Z) order (X being the
+  outer loop, Z the inner loop in the array)'
 fields:
   DATA:
     full_name: ONDE_DATASET:DATA
@@ -32,7 +50,7 @@ fields:
     storage: A or D
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_ASCAN_DATASET> or H5T_INTEGER
     description: can be either an array or a reference to an array
-    dimensions: 1 or [N_DF<m>,N_ROW<m>,N_COL<m>] or [N_DF<m>,NROW<m>,NCOL<m>,N_PLANE<m>]
+    dimensions: 1 or [N_U<m>,N_V<m>,N_ROW<m>,N_COL<m>] or [N_U<m>,N_V<m>NROW<m>,NCOL<m>,N_PLANE<m>]
   ZONE_FRAME:
     full_name: ONDE_DATASET_UT_TSCAN:ZONE_FRAME
     required: true

--- a/class_definitions/onde_dataset_ut_tscan.yaml
+++ b/class_definitions/onde_dataset_ut_tscan.yaml
@@ -3,40 +3,40 @@ inherits:
 - ONDE_DATASET_UT
 description: |-
     ### Tscan datasets
-  
-    **General**
-  
+
+    #### General
+
     Even though the name (Tscans coming from TFM Scans) implicitly refers to the TFM reconstruction images, the block can
     apply to any reconstruction method producing data on a rectangular/parallelepiped grid that moves with the sensor (be it
     obtained by TFM, Adaptive TFM, PWI, Adaptive PWI, frequency reconstruction, or any variant of these methods)
-  
-    **Underlying data**
-    The ELEMENTARY_CHANNELS_DATASET points to the Ascan dataset that was used to create the reconstruction. 
+
+    #### Underlying data
+    The ELEMENTARY_CHANNELS_DATASET points to the Ascan dataset that was used to create the reconstruction.
     It is a mandatory attribute (the Ascan dataset structure can contain no data if the elementary channels were not recorded).
-  
-    **3D Zones**
-  
+
+    #### 3D Zones
+
     The format allows for the description of 3D zones. Taking into account the dimension related to positions, this implies
     that the dimension of the data array depends on the zone dimension (3D array for 2D zones 4D array for 3D zones),
-  
-    **Zone dimension and position**
-  
+
+    #### Zone dimension and position
+
     The zone physical dimension is given by the ZONE_DIMENSION field, (DX,DY,DZ) being the physical dimensions of the zone,
     a zero or a NaN for one of the dimension implies a 2D zone.
-  
+
     ZONE_SIZE is a triplet which gives the number of pixels of the zone for each dimension (NX,NY,NZ).
-  
+
     The zone position is given by ZONE_FRAME and is expressed relatively to the trajectory of the probe which is given in the associated GEOMETRIC_SETUP probe list. The index of the probe in this list is given by the REFERENCE_PROBE_INDEX attribute (defaults to 0).
-  
+
     ![Example of TFM zone positioning](../images/media/tfm_zone_positioning.png "Figure 5")
-  
+
     *[Figure 5](onde_dataset_ut_tscan.md): Example of TFM zone positioning*
-  
+
     In the example displayed in [Figure 5](onde_dataset_ut_tscan.md), the trajectory frame is located at the index point and the zone is positioned
     accordingly.
-  
-    **Pixel ordering**
-  
+
+    #### Pixel ordering
+
     The pixels are stored in the (X,Y,Z) order (X being the outer loop, Z the inner loop in the array)
 fields:
   DATA:

--- a/class_definitions/onde_geometric_setup.yaml
+++ b/class_definitions/onde_geometric_setup.yaml
@@ -1,28 +1,18 @@
 onde_class: ONDE_GEOMETRIC_SETUP
 inherits: []
-description: '### Geometric setup
-
-
-  **Description**
-
-
-  The geometric setup contains references to the inspected component, the probes and
-  the trajectory. If the specimen
-
-  description is missing, a semi-infinite half-plane is assumed, with interface at
-  z=0 and material for z>0.
-
-
-  **Trajectories**
-
-
-  ACQUISITION_TRAJECTORY gives references to the groups describing the trajectory
-  -- references have the same order as
-
-  PROBE_LIST. PROBE_COORDINATE_FRAME can be used to define an offset between a referenced
-  trajectory and the probe -
-
-  identity is assumed if not provided.'
+description: |-
+    ### Geometric setup
+  
+    **Description**
+  
+    The geometric setup contains references to the inspected component, the probes and the trajectory. If the specimen
+    description is missing, a semi-infinite half-plane is assumed, with interface at z=0 and material for z>0.
+  
+    **Trajectories**
+  
+    ACQUISITION_TRAJECTORY gives references to the groups describing the trajectory -- references have the same order as
+    PROBE_LIST. PROBE_COORDINATE_FRAME can be used to define an offset between a referenced trajectory and the probe -
+    identity is assumed if not provided.
 fields:
   COMPONENT:
     full_name: ONDE_GEOMETRIC_SETUP:COMPONENT

--- a/class_definitions/onde_geometric_setup.yaml
+++ b/class_definitions/onde_geometric_setup.yaml
@@ -2,14 +2,14 @@ onde_class: ONDE_GEOMETRIC_SETUP
 inherits: []
 description: |-
     ### Geometric setup
-  
-    **Description**
-  
+
+    #### Description
+
     The geometric setup contains references to the inspected component, the probes and the trajectory. If the specimen
     description is missing, a semi-infinite half-plane is assumed, with interface at z=0 and material for z>0.
-  
-    **Trajectories**
-  
+
+    #### Trajectories
+
     ACQUISITION_TRAJECTORY gives references to the groups describing the trajectory -- references have the same order as
     PROBE_LIST. PROBE_COORDINATE_FRAME can be used to define an offset between a referenced trajectory and the probe -
     identity is assumed if not provided.

--- a/class_definitions/onde_phased_array_angle.yaml
+++ b/class_definitions/onde_phased_array_angle.yaml
@@ -1,18 +1,14 @@
 onde_class: ONDE_PHASED_ARRAY_ANGLE
 inherits:
 - ONDE_PHASED_ARRAY_SETUP
-description: '**Angle**
-
-
-  In this configuration (see [Figure 24](onde_phased_array_angle.md)), a single angle
-  is provided for the specification of the ultrasonic ray direction.
-
-
-  ![Inspection using a single angle](../images/media/single_angle_inspection.png "Figure
-  24")
-
-
-  *[Figure 24](onde_phased_array_angle.md): Inspection using a single angle*'
+description: |-
+    **Angle**
+  
+    In this configuration (see [Figure 24](onde_phased_array_angle.md)), a single angle is provided for the specification of the ultrasonic ray direction.
+  
+    ![Inspection using a single angle](../images/media/single_angle_inspection.png "Figure 24")
+  
+    *[Figure 24](onde_phased_array_angle.md): Inspection using a single angle*
 fields:
   BSCAN_ANGLE:
     full_name: ONDE_PHASED_ARRAY_ANGLE:BSCAN_ANGLE

--- a/class_definitions/onde_phased_array_angle.yaml
+++ b/class_definitions/onde_phased_array_angle.yaml
@@ -2,12 +2,12 @@ onde_class: ONDE_PHASED_ARRAY_ANGLE
 inherits:
 - ONDE_PHASED_ARRAY_SETUP
 description: |-
-    **Angle**
-  
+    #### Angle
+
     In this configuration (see [Figure 24](onde_phased_array_angle.md)), a single angle is provided for the specification of the ultrasonic ray direction.
-  
+
     ![Inspection using a single angle](../images/media/single_angle_inspection.png "Figure 24")
-  
+
     *[Figure 24](onde_phased_array_angle.md): Inspection using a single angle*
 fields:
   BSCAN_ANGLE:

--- a/class_definitions/onde_phased_array_compound.yaml
+++ b/class_definitions/onde_phased_array_compound.yaml
@@ -1,34 +1,22 @@
 onde_class: ONDE_PHASED_ARRAY_COMPOUND
 inherits:
 - ONDE_PHASED_ARRAY_SETUP
-description: '**Compound**
-
-
-  The compound type mixes Escan and Sscan behavior (see [Figure 27](onde_phased_array_compound.md)).
-  COMPOUND_INITIAL_ANGLE, COMPOUND_FINAL_ANGLE and
-
-  COMPOUND_NUMBER_OF_ANGLES give the angle scope, while COMPOUND_NUMBER_OF_ELEMENTS
-  gives the number of elements in the
-
-  electronic scanning.
-
-
-  ![Compound configuration](../images/media/compound_config.png "Figure 27")
-
-
-  *[Figure 27](onde_phased_array_compound.md): Compound configuration*
-
-
-  ## Limitations
-
-
-  This block has no vocation to be exhaustive in terms of electronic configurations
-  (unlike the law block that permits any
-
-  description and is fully generic). However, it is intended to cover most of the
-  situations that are common in industrial
-
-  controls and represent a large share of the acquisition files produced in the industry.'
+description: |-
+    **Compound**
+  
+    The compound type mixes Escan and Sscan behavior (see [Figure 27](onde_phased_array_compound.md)). COMPOUND_INITIAL_ANGLE, COMPOUND_FINAL_ANGLE and
+    COMPOUND_NUMBER_OF_ANGLES give the angle scope, while COMPOUND_NUMBER_OF_ELEMENTS gives the number of elements in the
+    electronic scanning.
+  
+    ![Compound configuration](../images/media/compound_config.png "Figure 27")
+  
+    *[Figure 27](onde_phased_array_compound.md): Compound configuration*
+  
+    ## Limitations
+  
+    This block has no vocation to be exhaustive in terms of electronic configurations (unlike the law block that permits any
+    description and is fully generic). However, it is intended to cover most of the situations that are common in industrial
+    controls and represent a large share of the acquisition files produced in the industry.
 fields:
   INITIAL_ANGLE:
     full_name: ONDE_PHASED_ARRAY_COMPOUND:INITIAL_ANGLE

--- a/class_definitions/onde_phased_array_compound.yaml
+++ b/class_definitions/onde_phased_array_compound.yaml
@@ -2,18 +2,18 @@ onde_class: ONDE_PHASED_ARRAY_COMPOUND
 inherits:
 - ONDE_PHASED_ARRAY_SETUP
 description: |-
-    **Compound**
-  
+    #### Compound
+
     The compound type mixes Escan and Sscan behavior (see [Figure 27](onde_phased_array_compound.md)). COMPOUND_INITIAL_ANGLE, COMPOUND_FINAL_ANGLE and
     COMPOUND_NUMBER_OF_ANGLES give the angle scope, while COMPOUND_NUMBER_OF_ELEMENTS gives the number of elements in the
     electronic scanning.
-  
+
     ![Compound configuration](../images/media/compound_config.png "Figure 27")
-  
+
     *[Figure 27](onde_phased_array_compound.md): Compound configuration*
-  
+
     ## Limitations
-  
+
     This block has no vocation to be exhaustive in terms of electronic configurations (unlike the law block that permits any
     description and is fully generic). However, it is intended to cover most of the situations that are common in industrial
     controls and represent a large share of the acquisition files produced in the industry.

--- a/class_definitions/onde_phased_array_escan.yaml
+++ b/class_definitions/onde_phased_array_escan.yaml
@@ -1,22 +1,16 @@
 onde_class: ONDE_PHASED_ARRAY_ESCAN
 inherits:
 - ONDE_PHASED_ARRAY_SETUP
-description: '**EScan**
-
-
-  In this configuration consecutive subsets of elements are used in order to form
-  a beam at a specific angle, thus forming
-
-  a sweeping set of ultrasonic beams. [Figure 26](onde_phased_array_escan.md) illustrates
-  an Escan for 4 consecutive elements with a step of 3 elements
-
-  on a 32 element linear transducer.
-
-
-  ![EScan configuration](../images/media/escan_config.png "Figure 26")
-
-
-  *[Figure 26](onde_phased_array_escan.md): EScan configuration*'
+description: |-
+    **EScan**
+  
+    In this configuration consecutive subsets of elements are used in order to form a beam at a specific angle, thus forming
+    a sweeping set of ultrasonic beams. [Figure 26](onde_phased_array_escan.md) illustrates an Escan for 4 consecutive elements with a step of 3 elements
+    on a 32 element linear transducer.
+  
+    ![EScan configuration](../images/media/escan_config.png "Figure 26")
+  
+    *[Figure 26](onde_phased_array_escan.md): EScan configuration*
 fields:
   NUMBER_OF_ELEMENTS:
     full_name: ONDE_PHASED_ARRAY_ESCAN:NUMBER_OF_ELEMENTS

--- a/class_definitions/onde_phased_array_escan.yaml
+++ b/class_definitions/onde_phased_array_escan.yaml
@@ -2,14 +2,14 @@ onde_class: ONDE_PHASED_ARRAY_ESCAN
 inherits:
 - ONDE_PHASED_ARRAY_SETUP
 description: |-
-    **EScan**
-  
+    #### EScan
+
     In this configuration consecutive subsets of elements are used in order to form a beam at a specific angle, thus forming
     a sweeping set of ultrasonic beams. [Figure 26](onde_phased_array_escan.md) illustrates an Escan for 4 consecutive elements with a step of 3 elements
     on a 32 element linear transducer.
-  
+
     ![EScan configuration](../images/media/escan_config.png "Figure 26")
-  
+
     *[Figure 26](onde_phased_array_escan.md): EScan configuration*
 fields:
   NUMBER_OF_ELEMENTS:

--- a/class_definitions/onde_phased_array_setup.yaml
+++ b/class_definitions/onde_phased_array_setup.yaml
@@ -1,17 +1,26 @@
 onde_class: ONDE_PHASED_ARRAY_SETUP
 inherits: []
-description: "### Phased Array Setup\n\n**Type of inspection**\n\nThis optional group\
-  \ has no vocation to be exhaustive in terms of electronic configurations (unlike\
-  \ the law block that\npermits any description and is fully generic). However, it\
-  \ is intended to cover most of the situations that are common\nin industrial controls\
-  \ and represent a large share of the acquisition files produced in the industry.\
-  \ In this version of\nthe specification, it encompasses only the most basic setups.\
-  \ The SEQUENCE_TYPE field describes the sequence with the\nfollowing choice : ANGLE,\
-  \ SSCAN, ESCAN, COMPOUND, FMC, PWI, CUSTOM. The propagation mode used for the settings\
-  \ is given\nin SEQUENCE_ANGLE_MODE.\n\n```mermaid\nclassDiagram\n  phased_array_setup\
-  \ <|-- angle\n  phased_array_setup <|-- sscan\n  phased_array_setup <|-- escan\n\
-  \  phased_array_setup <|-- compound\n  phased_array_setup <|-- fmc\n  phased_array_setup\
-  \ <|-- pwi\n```"
+description: |-
+    ### Phased Array Setup
+  
+    **Type of inspection**
+  
+    This optional group has no vocation to be exhaustive in terms of electronic configurations (unlike the law block that
+    permits any description and is fully generic). However, it is intended to cover most of the situations that are common
+    in industrial controls and represent a large share of the acquisition files produced in the industry. In this version of
+    the specification, it encompasses only the most basic setups. The SEQUENCE_TYPE field describes the sequence with the
+    following choice : ANGLE, SSCAN, ESCAN, COMPOUND, FMC, PWI, CUSTOM. The propagation mode used for the settings is given
+    in SEQUENCE_ANGLE_MODE.
+  
+    ```mermaid
+    classDiagram
+      phased_array_setup <|-- angle
+      phased_array_setup <|-- sscan
+      phased_array_setup <|-- escan
+      phased_array_setup <|-- compound
+      phased_array_setup <|-- fmc
+      phased_array_setup <|-- pwi
+    ```
 fields:
   EMITTER_PROBE:
     full_name: ONDE_PHASED_ARRAY_SETUP:EMITTER_PROBE

--- a/class_definitions/onde_phased_array_setup.yaml
+++ b/class_definitions/onde_phased_array_setup.yaml
@@ -2,16 +2,16 @@ onde_class: ONDE_PHASED_ARRAY_SETUP
 inherits: []
 description: |-
     ### Phased Array Setup
-  
-    **Type of inspection**
-  
+
+    #### Type of inspection
+
     This optional group has no vocation to be exhaustive in terms of electronic configurations (unlike the law block that
     permits any description and is fully generic). However, it is intended to cover most of the situations that are common
     in industrial controls and represent a large share of the acquisition files produced in the industry. In this version of
     the specification, it encompasses only the most basic setups. The SEQUENCE_TYPE field describes the sequence with the
     following choice : ANGLE, SSCAN, ESCAN, COMPOUND, FMC, PWI, CUSTOM. The propagation mode used for the settings is given
     in SEQUENCE_ANGLE_MODE.
-  
+
     ```mermaid
     classDiagram
       phased_array_setup <|-- angle

--- a/class_definitions/onde_phased_array_sscan.yaml
+++ b/class_definitions/onde_phased_array_sscan.yaml
@@ -1,20 +1,15 @@
 onde_class: ONDE_PHASED_ARRAY_SSCAN
 inherits:
 - ONDE_PHASED_ARRAY_SETUP
-description: '**SScan**
-
-
-  In this configuration (see [Figure 25](onde_phased_array_sscan.md)), the probe is
-  configured to emit/receive at a set of angles. The angles are
-
-  linearly varying, therefore the first and last angles and the number of shots define
-  the set of angles.
-
-
-  ![SScan configuration](../images/media/sscan_config.png "Figure 25")
-
-
-  *[Figure 25](onde_phased_array_sscan.md): SScan configuration*'
+description: |-
+    **SScan**
+  
+    In this configuration (see [Figure 25](onde_phased_array_sscan.md)), the probe is configured to emit/receive at a set of angles. The angles are
+    linearly varying, therefore the first and last angles and the number of shots define the set of angles.
+  
+    ![SScan configuration](../images/media/sscan_config.png "Figure 25")
+  
+    *[Figure 25](onde_phased_array_sscan.md): SScan configuration*
 fields:
   STARTING_ANGLE:
     full_name: ONDE_PHASED_ARRAY_SSCAN:STARTING_ANGLE

--- a/class_definitions/onde_phased_array_sscan.yaml
+++ b/class_definitions/onde_phased_array_sscan.yaml
@@ -2,13 +2,13 @@ onde_class: ONDE_PHASED_ARRAY_SSCAN
 inherits:
 - ONDE_PHASED_ARRAY_SETUP
 description: |-
-    **SScan**
-  
+    #### SScan
+
     In this configuration (see [Figure 25](onde_phased_array_sscan.md)), the probe is configured to emit/receive at a set of angles. The angles are
     linearly varying, therefore the first and last angles and the number of shots define the set of angles.
-  
+
     ![SScan configuration](../images/media/sscan_config.png "Figure 25")
-  
+
     *[Figure 25](onde_phased_array_sscan.md): SScan configuration*
 fields:
   STARTING_ANGLE:

--- a/class_definitions/onde_plane.yaml
+++ b/class_definitions/onde_plane.yaml
@@ -1,23 +1,16 @@
 onde_class: ONDE_PLANE
 inherits:
 - ONDE_COMPONENT
-description: '**Conventions for planar specimens**
-
-
-  In the planar coordinate system, the z direction is defined as the one corresponding
-  to the thickness of the inspected
-
-  specimen (see [Figure 6](onde_plane.md)). The dimensions are given by PLATE_DIMENSIONS,
-  as a triplet with values for length, width, and
-
-  thickness.
-
-
-  ![Trajectory planar coordinate system convention](../images/media/trajectory_planar_coords.png
-  "Figure 6")
-
-
-  *[Figure 6](onde_plane.md): Trajectory planar coordinate system convention*'
+description: |-
+    **Conventions for planar specimens**
+  
+    In the planar coordinate system, the z direction is defined as the one corresponding to the thickness of the inspected
+    specimen (see [Figure 6](onde_plane.md)). The dimensions are given by PLATE_DIMENSIONS, as a triplet with values for length, width, and
+    thickness.
+  
+    ![Trajectory planar coordinate system convention](../images/media/trajectory_planar_coords.png "Figure 6")
+  
+    *[Figure 6](onde_plane.md): Trajectory planar coordinate system convention*
 fields:
   PLATE_DIMENSIONS:
     full_name: ONDE_PLANE:PLATE_DIMENSIONS

--- a/class_definitions/onde_plane.yaml
+++ b/class_definitions/onde_plane.yaml
@@ -2,14 +2,14 @@ onde_class: ONDE_PLANE
 inherits:
 - ONDE_COMPONENT
 description: |-
-    **Conventions for planar specimens**
-  
+    #### Conventions for planar specimens
+
     In the planar coordinate system, the z direction is defined as the one corresponding to the thickness of the inspected
     specimen (see [Figure 6](onde_plane.md)). The dimensions are given by PLATE_DIMENSIONS, as a triplet with values for length, width, and
     thickness.
-  
+
     ![Trajectory planar coordinate system convention](../images/media/trajectory_planar_coords.png "Figure 6")
-  
+
     *[Figure 6](onde_plane.md): Trajectory planar coordinate system convention*
 fields:
   PLATE_DIMENSIONS:

--- a/class_definitions/onde_setup.yaml
+++ b/class_definitions/onde_setup.yaml
@@ -1,11 +1,9 @@
 onde_class: ONDE_SETUP
 inherits: []
-description: '### Setup
-
-
-  The setup block contains references to the ultrasonic setup and the geometric setup.
-
-  '
+description: |
+    ### Setup
+  
+    The setup block contains references to the ultrasonic setup and the geometric setup.
 fields:
   GEOMETRIC_SETUP:
     full_name: ONDE_SETUP:GEOMETRIC_SETUP

--- a/class_definitions/onde_setup.yaml
+++ b/class_definitions/onde_setup.yaml
@@ -2,7 +2,7 @@ onde_class: ONDE_SETUP
 inherits: []
 description: |
     ### Setup
-  
+
     The setup block contains references to the ultrasonic setup and the geometric setup.
 fields:
   GEOMETRIC_SETUP:

--- a/class_definitions/onde_spatial_trajectory.yaml
+++ b/class_definitions/onde_spatial_trajectory.yaml
@@ -1,7 +1,22 @@
 onde_class: ONDE_SPATIAL_TRAJECTORY
 inherits:
 - ONDE_ACQUISITION_TRAJECTORY
-description: ''
+description: "### Spatial trajectory
+
+  The spatial trajectory is a list of positions and orientations of the acquisition
+  frame. It is given in the global reference frame.
+  ONDE format gives the possibility to describe a generic trajectory, as well as a grid trajectory
+  (1D or 2D) for which the acquisition grid is defined. When the grid trajectory is defined, the Spatial trajectory  is subtyped in the 
+  ONDE_GRID_TRAJECTORY class, which inherits from the ONDE_SPATIAL_TRAJECTORY class.
+  The array describing the list of positions and orientations is stored in the TRAJECTORY field. It is a 3D array of size [N_U<m>, N_V<m>, 7], 
+  where N_U and N_V are the number of positions along the U and V directions, respectively.
+  The last dimension of size 7 corresponds to the position (x, y, z) and the orientation (quaternion q0, q1, q2, q3) of the acquisition frame at each position.
+  
+#### Notes
+
+  N_V will be set to 1 for 1D trajectories (whether 1D spatial trajectories or time trajectories)
+  
+  "
 fields:
   TRAJECTORY:
     full_name: ONDE_SPATIAL_TRAJECTORY:TRAJECTORY
@@ -10,4 +25,4 @@ fields:
     hdf5_type: H5T_FLOAT
     description: List of positions and quaternions giving the positions and orientations
       of the trajectory frame at the different positions
-    dimensions: '[N_Pos<m>,7]'
+    dimensions: '[N_U<m>,N_V<m>,7]'

--- a/class_definitions/onde_time_trajectory.yaml
+++ b/class_definitions/onde_time_trajectory.yaml
@@ -1,14 +1,11 @@
 onde_class: ONDE_TIME_TRAJECTORY
 inherits:
 - ONDE_ACQUISITION_TRAJECTORY
-description: '**Time encoding**
-
-
-  For acquisition having no spatial encoding, the format allows to describe time encoding.
-  This is achieved by setting the
-
-  TRAJECTORY_TYPE field. In the case of time encoding, the ACQUISITION_RATE must be
-  specified.'
+description: |-
+    **Time encoding**
+  
+    For acquisition having no spatial encoding, the format allows to describe time encoding. This is achieved by setting the
+    TRAJECTORY_TYPE field. In the case of time encoding, the ACQUISITION_RATE must be specified.
 fields:
   ACQUISITION_RATE:
     full_name: ONDE_TIME_TRAJECTORY:ACQUISITION_RATE

--- a/class_definitions/onde_time_trajectory.yaml
+++ b/class_definitions/onde_time_trajectory.yaml
@@ -2,8 +2,8 @@ onde_class: ONDE_TIME_TRAJECTORY
 inherits:
 - ONDE_ACQUISITION_TRAJECTORY
 description: |-
-    **Time encoding**
-  
+    #### Time encoding
+
     For acquisition having no spatial encoding, the format allows to describe time encoding. This is achieved by setting the
     TRAJECTORY_TYPE field. In the case of time encoding, the ACQUISITION_RATE must be specified.
 fields:

--- a/class_definitions/onde_ultrasonic_setup.yaml
+++ b/class_definitions/onde_ultrasonic_setup.yaml
@@ -1,42 +1,69 @@
 onde_class: ONDE_ULTRASONIC_SETUP
 inherits: []
-description: "\n### Ultrasonic setup\n\n**Acquisition gate**\n\nThe acquisition gate\
-  \ is implicitly defined by:\n\n- the value of Ascan_Astart\n- the sampling frequency\n\
-  - the dimension of data N_Time\\<m\\>\n\nt0 : ASCAN_ASTART\n\ntend : ASCAN_ASTART\
-  \ + (N_Time\\<m\\> - 1)/ASCAN_SAMPLE_RATE\n\n**Gain**\n\nGAIN indicates the total\
-  \ gain for each A-scan during reception. It is a multiplying factor that was applied\
-  \ at\nacquisition.\n\n**TCG curves**. The curve is specified in the TCG_CURVE field.\
-  \ It is provided for the entire acquisition gate. The\namplification must be cumulated\
-  \ to the global one defined by the GAIN attribute.\n\n**Laws**\n\nEach A-scan in\
-  \ a dataframe must be associated with both a transmit and a receive focal law through\
-  \ the RECEIVE_LAW and\nTRANSMIT_LAW datafields. These contain HDF5 references to\
-  \ the groups which provide the detailed description of each\nfocal laws (the same\
-  \ structure is used for both transmit and receive focal laws). PRF indicates the\
-  \ pulse repetition\nfrequency for each Tx/Rx combination\n\n**Dynamic laws**\n\n\
-  In order to allow advanced setups with different laws defined for each acquisition\
-  \ position, the cardinality of the\ntransmission and reception can be either a 1D-array\
-  \ (same laws applied for each dataframe) or 2D (differentiated laws).\n\n**Filter\
-  \ Parameters**\n\nThe filtering parameters take different values following the filter\
-  \ type.\n\n- For FILTER_TYPE HIGH_PASS or LOW_PASS this is a single value giving\
-  \ the -3 dB cut-off frequency\n- For FILTER_TYPE BAND_PASS this should contain two\
-  \ values for the lower and upper -3 dB cut-off frequencies\n- For FILTER_TYPE OTHER,\
-  \ this should be an \\[3,N_DF\\<m\\>\\] matrix where the first row is frequency\
-  \ and the second and\n  third rows provide the real and imaginary parts of the filter's\
-  \ transfer function at that frequency.\n\n**Combination between offsets and trajectories**\n\
-  \nThe offsets and directions provided in the dataset blocks can be combined to the\
-  \ data of the trajectory block in order\nto share common trajectories between different\
-  \ probes (as is common in TOFD controls for example). In this case, the\ntrajectories\
-  \ links point to the same trajectory objects and the offsets/rotation between the\
-  \ trajectory and the probe\nPCF describe the relative positions of the different\
-  \ probes with respect to the trajectory frame. A typical example is\nillustrated\
-  \ in [Figure 23](onde_ultrasonic_setup.md), with a trajectory frame given at the\
-  \ Probe Center Separation and offsets used to define the\nPCF locations. If the\
-  \ offset is not provided, the PCF and trajectory frame are assumed to be the same.\n\
-  \n![Example of offset and trajectory combination in the case of a TOFD inspection](../images/media/tofd_inspection_trajectory.png\
-  \ \"Figure 23\")\n\n*[Figure 23](onde_ultrasonic_setup.md): Example of offset and\
-  \ trajectory combination in the case of a TOFD inspection*\n\n**Variable gates**\n\
-  \nVariable gates are not handled in this version -- it can be emulated by zero---padding\
-  \ the data block"
+description: "### Ultrasonic setup
+
+#### Acquisition gate
+
+The acquisition gate is implicitly defined by:
+- the value of Ascan_Astart
+- the sampling frequency
+- the dimension of data N_Time<m>
+t0 : ASCAN_ASTART\n\ntend : ASCAN_ASTART\
+  \ + (N_Time\\<m\\> - 1)/ASCAN_SAMPLE_RATE
+  
+####Gain
+  
+  GAIN indicates the total gain for each A-scan during reception. It is a multiplying factor that was applied
+  at acquisition.
+  
+####TCG curves
+
+The curve is specified in the TCG_CURVE field. It is provided for the entire acquisition gate. The amplification must be cumulated
+to the global one defined by the GAIN attribute.
+
+####Laws
+
+Each A-scan in a dataframe must be associated with both a transmit and a receive focal law through 
+the RECEIVE_LAW and TRANSMIT_LAW datafields. These contain HDF5 references tothe groups which provide 
+the detailed description of each\nfocal laws (the same structure is used for both transmit and receive focal laws). PRF indicates the
+  \ pulse repetition\nfrequency for each Tx/Rx combination
+  
+#### Dynamic laws
+
+  In order to allow advanced setups with different laws defined for each acquisition
+  position, the cardinality of the\ntransmission and reception can be either a 1D-array
+  (same laws applied for each dataframe) or 2D (differentiated laws).
+  
+####Filter Parameters
+
+The filtering parameters take different values following the filtertype.
+
+- For FILTER_TYPE HIGH_PASS or LOW_PASS this is a single value giving the -3 dB cut-off frequency
+- For FILTER_TYPE BAND_PASS this should contain two values for the lower and upper -3 dB cut-off frequencies
+- For FILTER_TYPE OTHER, this should be an [3,N_U<m>, N_V<m>] matrix where the first row is frequency
+  and the second and  third rows provide the real and imaginary parts of the filter's
+  transfer function at that frequency.
+  
+  #### Combination between offsets and trajectories
+
+  The offsets and directions provided in the dataset blocks can be combined to the
+   data of the trajectory block in order\nto share common trajectories between different
+  probes (as is common in TOFD controls for example). In this case, the\ntrajectories
+  links point to the same trajectory objects and the offsets/rotation between the
+  trajectory and the probe\nPCF describe the relative positions of the different
+  probes with respect to the trajectory frame. A typical example is\nillustrated
+  in [Figure 23](onde_ultrasonic_setup.md), with a trajectory frame given at the
+  Probe Center Separation and offsets used to define the PCF locations. If the
+  offset is not provided, the PCF and trajectory frame are assumed to be the same.
+  ![Example of offset and trajectory combination in the case of a TOFD inspection](../images/media/tofd_inspection_trajectory.png\
+  \ \"Figure 23\")
+  
+  *[Figure 23](onde_ultrasonic_setup.md): Example of offset and\
+  \ trajectory combination in the case of a TOFD inspection*
+  
+  #### Variable gates
+  
+  Variable gates are not handled in this version -- it can be emulated by zero---padding the data block"
 fields:
   LABEL:
     full_name: ONDE:LABEL
@@ -67,8 +94,8 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: Optional datafield providing analogue filter parameters - see notes
-      for detailed explanation
-    dimensions: 1 or [N_Ascan<m>] or [ N_DF<m>,N_Ascan<m>]
+      for detailed explanation of the different filter types and their parameters
+    dimensions: 1 or [N_Ascan<m>] or [ N_U<m>,N_V<m>,N_Ascan<m>]
   FILTER_DESCRIPTION:
     full_name: ONDE_ULTRASONIC_SETUP:FILTER_DESCRIPTION
     required: false
@@ -92,7 +119,7 @@ fields:
     description: This indicates the starting time for data acquisition. If dimension
       is 1, the same start time is used for all A-Scans, else a different start time
       is specified for each A-Scan.
-    dimensions: 1 or [N_Ascan<m>] or [ N_Ascan<m>,N_DF<m>]
+    dimensions: 1 or [N_Ascan<m>] or [ N_Ascan<m>,N_U<m>, N_V<m>]
   SIGNAL:
     full_name: ONDE_ULTRASONIC_SETUP:SIGNAL
     required: false
@@ -142,11 +169,11 @@ fields:
       to the groups which provide the detailed description of each focal laws (the
       same structure is used for both transmit and receive focal laws). Mandatory
       for phased array setups.
-    dimensions: '[N_Ascan<m>] or [N_DF<m>,N_Ascan<m>]'
+    dimensions: '[N_Ascan<m>] or [N_U<m>, N_V<m>, N_Ascan<m>]'
   RECEIVE_LAW:
     full_name: ONDE_ULTRASONIC_SETUP:RECEIVE_LAW
     required: false
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_LAW>
     description: Each A-scan in a dataframe must be associated with both a transmit and a receive focal law through the datafields. These contain HDF5 references to the groups which provide the detailed description of each focal laws (the same structure is used for both transmit and receive focal laws).Mandatory for phased array setups.
-    dimensions: '[N_Ascan<m>] or [N_DF<m>,N_Ascan<m>]'
+    dimensions: '[N_Ascan<m>] or [N_U<m>, N_V<m>, N_Ascan<m>]'

--- a/class_definitions/onde_ultrasonic_setup.yaml
+++ b/class_definitions/onde_ultrasonic_setup.yaml
@@ -1,42 +1,66 @@
 onde_class: ONDE_ULTRASONIC_SETUP
 inherits: []
-description: "\n### Ultrasonic setup\n\n**Acquisition gate**\n\nThe acquisition gate\
-  \ is implicitly defined by:\n\n- the value of Ascan_Astart\n- the sampling frequency\n\
-  - the dimension of data N_Time\\<m\\>\n\nt0 : ASCAN_ASTART\n\ntend : ASCAN_ASTART\
-  \ + (N_Time\\<m\\> - 1)/ASCAN_SAMPLE_RATE\n\n**Gain**\n\nGAIN indicates the total\
-  \ gain for each A-scan during reception. It is a multiplying factor that was applied\
-  \ at\nacquisition.\n\n**TCG curves**. The curve is specified in the TCG_CURVE field.\
-  \ It is provided for the entire acquisition gate. The\namplification must be cumulated\
-  \ to the global one defined by the GAIN attribute.\n\n**Laws**\n\nEach A-scan in\
-  \ a dataframe must be associated with both a transmit and a receive focal law through\
-  \ the RECEIVE_LAW and\nTRANSMIT_LAW datafields. These contain HDF5 references to\
-  \ the groups which provide the detailed description of each\nfocal laws (the same\
-  \ structure is used for both transmit and receive focal laws). PRF indicates the\
-  \ pulse repetition\nfrequency for each Tx/Rx combination\n\n**Dynamic laws**\n\n\
-  In order to allow advanced setups with different laws defined for each acquisition\
-  \ position, the cardinality of the\ntransmission and reception can be either a 1D-array\
-  \ (same laws applied for each dataframe) or 2D (differentiated laws).\n\n**Filter\
-  \ Parameters**\n\nThe filtering parameters take different values following the filter\
-  \ type.\n\n- For FILTER_TYPE HIGH_PASS or LOW_PASS this is a single value giving\
-  \ the -3 dB cut-off frequency\n- For FILTER_TYPE BAND_PASS this should contain two\
-  \ values for the lower and upper -3 dB cut-off frequencies\n- For FILTER_TYPE OTHER,\
-  \ this should be an \\[3,N_DF\\<m\\>\\] matrix where the first row is frequency\
-  \ and the second and\n  third rows provide the real and imaginary parts of the filter's\
-  \ transfer function at that frequency.\n\n**Combination between offsets and trajectories**\n\
-  \nThe offsets and directions provided in the dataset blocks can be combined to the\
-  \ data of the trajectory block in order\nto share common trajectories between different\
-  \ probes (as is common in TOFD controls for example). In this case, the\ntrajectories\
-  \ links point to the same trajectory objects and the offsets/rotation between the\
-  \ trajectory and the probe\nPCF describe the relative positions of the different\
-  \ probes with respect to the trajectory frame. A typical example is\nillustrated\
-  \ in [Figure 23](onde_ultrasonic_setup.md), with a trajectory frame given at the\
-  \ Probe Center Separation and offsets used to define the\nPCF locations. If the\
-  \ offset is not provided, the PCF and trajectory frame are assumed to be the same.\n\
-  \n![Example of offset and trajectory combination in the case of a TOFD inspection](../images/media/tofd_inspection_trajectory.png\
-  \ \"Figure 23\")\n\n*[Figure 23](onde_ultrasonic_setup.md): Example of offset and\
-  \ trajectory combination in the case of a TOFD inspection*\n\n**Variable gates**\n\
-  \nVariable gates are not handled in this version -- it can be emulated by zero---padding\
-  \ the data block"
+description: |-
+  
+    ### Ultrasonic setup
+  
+    **Acquisition gate**
+  
+    The acquisition gate is implicitly defined by:
+  
+    - the value of Ascan_Astart
+    - the sampling frequency
+    - the dimension of data N_Time\<m\>
+  
+    t0 : ASCAN_ASTART
+  
+    tend : ASCAN_ASTART + (N_Time\<m\> - 1)/ASCAN_SAMPLE_RATE
+  
+    **Gain**
+  
+    GAIN indicates the total gain for each A-scan during reception. It is a multiplying factor that was applied at
+    acquisition.
+  
+    **TCG curves**. The curve is specified in the TCG_CURVE field. It is provided for the entire acquisition gate. The
+    amplification must be cumulated to the global one defined by the GAIN attribute.
+  
+    **Laws**
+  
+    Each A-scan in a dataframe must be associated with both a transmit and a receive focal law through the RECEIVE_LAW and
+    TRANSMIT_LAW datafields. These contain HDF5 references to the groups which provide the detailed description of each
+    focal laws (the same structure is used for both transmit and receive focal laws). PRF indicates the pulse repetition
+    frequency for each Tx/Rx combination
+  
+    **Dynamic laws**
+  
+    In order to allow advanced setups with different laws defined for each acquisition position, the cardinality of the
+    transmission and reception can be either a 1D-array (same laws applied for each dataframe) or 2D (differentiated laws).
+  
+    **Filter Parameters**
+  
+    The filtering parameters take different values following the filter type.
+  
+    - For FILTER_TYPE HIGH_PASS or LOW_PASS this is a single value giving the -3 dB cut-off frequency
+    - For FILTER_TYPE BAND_PASS this should contain two values for the lower and upper -3 dB cut-off frequencies
+    - For FILTER_TYPE OTHER, this should be an \[3,N_DF\<m\>\] matrix where the first row is frequency and the second and
+      third rows provide the real and imaginary parts of the filter's transfer function at that frequency.
+  
+    **Combination between offsets and trajectories**
+  
+    The offsets and directions provided in the dataset blocks can be combined to the data of the trajectory block in order
+    to share common trajectories between different probes (as is common in TOFD controls for example). In this case, the
+    trajectories links point to the same trajectory objects and the offsets/rotation between the trajectory and the probe
+    PCF describe the relative positions of the different probes with respect to the trajectory frame. A typical example is
+    illustrated in [Figure 23](onde_ultrasonic_setup.md), with a trajectory frame given at the Probe Center Separation and offsets used to define the
+    PCF locations. If the offset is not provided, the PCF and trajectory frame are assumed to be the same.
+  
+    ![Example of offset and trajectory combination in the case of a TOFD inspection](../images/media/tofd_inspection_trajectory.png "Figure 23")
+  
+    *[Figure 23](onde_ultrasonic_setup.md): Example of offset and trajectory combination in the case of a TOFD inspection*
+  
+    **Variable gates**
+  
+    Variable gates are not handled in this version -- it can be emulated by zero---padding the data block
 fields:
   LABEL:
     full_name: ONDE:LABEL

--- a/class_definitions/onde_ultrasonic_setup.yaml
+++ b/class_definitions/onde_ultrasonic_setup.yaml
@@ -1,65 +1,67 @@
 onde_class: ONDE_ULTRASONIC_SETUP
 inherits: []
 description: |-
-  
+
     ### Ultrasonic setup
-  
-    **Acquisition gate**
-  
+
+    #### Acquisition gate
+
     The acquisition gate is implicitly defined by:
-  
+
     - the value of Ascan_Astart
     - the sampling frequency
     - the dimension of data N_Time\<m\>
-  
+
     t0 : ASCAN_ASTART
-  
+
     tend : ASCAN_ASTART + (N_Time\<m\> - 1)/ASCAN_SAMPLE_RATE
-  
-    **Gain**
-  
+
+    #### Gain
+
     GAIN indicates the total gain for each A-scan during reception. It is a multiplying factor that was applied at
     acquisition.
-  
-    **TCG curves**. The curve is specified in the TCG_CURVE field. It is provided for the entire acquisition gate. The
+
+    #### TCG curves
+
+    The curve is specified in the TCG_CURVE field. It is provided for the entire acquisition gate. The
     amplification must be cumulated to the global one defined by the GAIN attribute.
-  
-    **Laws**
-  
+
+    #### Laws
+
     Each A-scan in a dataframe must be associated with both a transmit and a receive focal law through the RECEIVE_LAW and
     TRANSMIT_LAW datafields. These contain HDF5 references to the groups which provide the detailed description of each
     focal laws (the same structure is used for both transmit and receive focal laws). PRF indicates the pulse repetition
     frequency for each Tx/Rx combination
-  
-    **Dynamic laws**
-  
+
+    #### Dynamic laws
+
     In order to allow advanced setups with different laws defined for each acquisition position, the cardinality of the
     transmission and reception can be either a 1D-array (same laws applied for each dataframe) or 2D (differentiated laws).
-  
-    **Filter Parameters**
-  
+
+    #### Filter Parameters
+
     The filtering parameters take different values following the filter type.
-  
+
     - For FILTER_TYPE HIGH_PASS or LOW_PASS this is a single value giving the -3 dB cut-off frequency
     - For FILTER_TYPE BAND_PASS this should contain two values for the lower and upper -3 dB cut-off frequencies
     - For FILTER_TYPE OTHER, this should be an \[3,N_DF\<m\>\] matrix where the first row is frequency and the second and
       third rows provide the real and imaginary parts of the filter's transfer function at that frequency.
-  
-    **Combination between offsets and trajectories**
-  
+
+    #### Combination between offsets and trajectories
+
     The offsets and directions provided in the dataset blocks can be combined to the data of the trajectory block in order
     to share common trajectories between different probes (as is common in TOFD controls for example). In this case, the
     trajectories links point to the same trajectory objects and the offsets/rotation between the trajectory and the probe
     PCF describe the relative positions of the different probes with respect to the trajectory frame. A typical example is
     illustrated in [Figure 23](onde_ultrasonic_setup.md), with a trajectory frame given at the Probe Center Separation and offsets used to define the
     PCF locations. If the offset is not provided, the PCF and trajectory frame are assumed to be the same.
-  
+
     ![Example of offset and trajectory combination in the case of a TOFD inspection](../images/media/tofd_inspection_trajectory.png "Figure 23")
-  
+
     *[Figure 23](onde_ultrasonic_setup.md): Example of offset and trajectory combination in the case of a TOFD inspection*
-  
-    **Variable gates**
-  
+
+    #### Variable gates
+
     Variable gates are not handled in this version -- it can be emulated by zero---padding the data block
 fields:
   LABEL:

--- a/class_definitions/onde_ut.yaml
+++ b/class_definitions/onde_ut.yaml
@@ -1,7 +1,7 @@
 modality: ONDE_UT
 description: |
   ### ONDE UT File
-  
+
   This class specifies the UT file type and provides a place for including top level fields. It explicitly references all of the classes that are allowed in this file type.
 allowed_classes:
   - ONDE_DATASET

--- a/class_definitions/onde_ut_elements.yaml
+++ b/class_definitions/onde_ut_elements.yaml
@@ -1,93 +1,52 @@
 onde_class: ONDE_UT_ELEMENTS
 inherits: []
-description: '**Element shapes**
-
-
-  The geometry of the elements is defined by the ELEMENT_SHAPE field. The shape of
-  each element will be defined as one of
-
-  the following: rectangle (ELE_GEOM_REC), part of a ring (ELE_GEOM_RING_PART), part
-  of an elliptical ring
-
-  (ELE_GEOM_ELLIPSE_PART).
-
-
-  The size is provided through 6 parameters in ELEMENT_SIZE. These 6 parameters indicate
-  the dimensions of each element
-
-  according to their geometry, see [Figure 12](onde_ut_elements.md).
-
-
-  For ELE_GEOM_REC : DIM_X1, DIM_Y, 0.0, 0.0, 0.0, 0.0.
-
-
-  For ELE_GEOM_RING_PART: r, e, theta_min, theta_max, 0.0, 0.0
-
-
-  For ELE_GEOM_ELLIPSE_PART: r_X, e_X, r_Y, e_Y, theta_min, theta_max
-
-
-  ![Different types of element shape](../images/media/element_shapes.png "Figure 12")
-
-
-  *[Figure 12](onde_ut_elements.md): Different types of element shape*
-
-
-  **Element positioning**
-
-
-  The ELEMENT_FRAME array defines the position and orientation of the probe elements
-  defined by their frames in the PCF.
-
-  For rectangular elements, x and y must be aligned with the main axes of the rectangle.
-  For elliptical elements, x and y
-
-  must be aligned with the major and the minor axes of the ellipse. For circular rings,
-  x and y simply must be coplanar
-
-  with the element. The frame should be orientated such that z is in the direction
-  of ultrasonic emission (see [definition of frames](index.md#definition-of-frames)).
-
-
-  **Element ordering convention**
-
-
-  For linear and matrix probes (see [Figure 13](onde_ut_elements.md)), the chosen
-  convention is as follows : numbering according to the minor
-
-  axis then according to the major axis, both in ascending order.
-
-
-  For annular, elliptical and bi-elliptical probes (see [Figure 13](onde_ut_elements.md)),
-  the chosen convention is as follows : numbering from
-
-  internal rings to external rings. On each ring, the numbering is done in ascending
-  order in the direct direction around
-
-  the Z axis of the probe, the origin being taken on the major axis.
-
-
-  For dual probes (see [Figure 14](onde_ut_elements.md)), the two probes have a symmetrical
-  cutout. The right probe has elements from 1 to N
-
-  following the numbering convention established previously. The left probe has elements
-  from N+1 to 2N with a numbering
-
-  symmetrical to that of the right probe according to the major axis.
-
-
-  ![Convention for element numbering](../images/media/element_numbering.png "Figure
-  13")
-
-
-  *[Figure 13](onde_ut_elements.md): Convention for element numbering*
-
-
-  ![Convention for dual probes element numbering](../images/media/dual_probes_element_numbering.png
-  "Figure 14")
-
-
-  *[Figure 14](onde_ut_elements.md): Convention for dual probes element numbering*'
+description: |-
+    **Element shapes**
+  
+    The geometry of the elements is defined by the ELEMENT_SHAPE field. The shape of each element will be defined as one of
+    the following: rectangle (ELE_GEOM_REC), part of a ring (ELE_GEOM_RING_PART), part of an elliptical ring
+    (ELE_GEOM_ELLIPSE_PART).
+  
+    The size is provided through 6 parameters in ELEMENT_SIZE. These 6 parameters indicate the dimensions of each element
+    according to their geometry, see [Figure 12](onde_ut_elements.md).
+  
+    For ELE_GEOM_REC : DIM_X1, DIM_Y, 0.0, 0.0, 0.0, 0.0.
+  
+    For ELE_GEOM_RING_PART: r, e, theta_min, theta_max, 0.0, 0.0
+  
+    For ELE_GEOM_ELLIPSE_PART: r_X, e_X, r_Y, e_Y, theta_min, theta_max
+  
+    ![Different types of element shape](../images/media/element_shapes.png "Figure 12")
+  
+    *[Figure 12](onde_ut_elements.md): Different types of element shape*
+  
+    **Element positioning**
+  
+    The ELEMENT_FRAME array defines the position and orientation of the probe elements defined by their frames in the PCF.
+    For rectangular elements, x and y must be aligned with the main axes of the rectangle. For elliptical elements, x and y
+    must be aligned with the major and the minor axes of the ellipse. For circular rings, x and y simply must be coplanar
+    with the element. The frame should be orientated such that z is in the direction of ultrasonic emission (see [definition of frames](index.md#definition-of-frames)).
+  
+    **Element ordering convention**
+  
+    For linear and matrix probes (see [Figure 13](onde_ut_elements.md)), the chosen convention is as follows : numbering according to the minor
+    axis then according to the major axis, both in ascending order.
+  
+    For annular, elliptical and bi-elliptical probes (see [Figure 13](onde_ut_elements.md)), the chosen convention is as follows : numbering from
+    internal rings to external rings. On each ring, the numbering is done in ascending order in the direct direction around
+    the Z axis of the probe, the origin being taken on the major axis.
+  
+    For dual probes (see [Figure 14](onde_ut_elements.md)), the two probes have a symmetrical cutout. The right probe has elements from 1 to N
+    following the numbering convention established previously. The left probe has elements from N+1 to 2N with a numbering
+    symmetrical to that of the right probe according to the major axis.
+  
+    ![Convention for element numbering](../images/media/element_numbering.png "Figure 13")
+  
+    *[Figure 13](onde_ut_elements.md): Convention for element numbering*
+  
+    ![Convention for dual probes element numbering](../images/media/dual_probes_element_numbering.png "Figure 14")
+  
+    *[Figure 14](onde_ut_elements.md): Convention for dual probes element numbering*
 fields:
   FRAME:
     full_name: ONDE_UT_ELEMENTS:FRAME

--- a/class_definitions/onde_ut_elements.yaml
+++ b/class_definitions/onde_ut_elements.yaml
@@ -1,51 +1,51 @@
 onde_class: ONDE_UT_ELEMENTS
 inherits: []
 description: |-
-    **Element shapes**
-  
+    #### Element shapes
+
     The geometry of the elements is defined by the ELEMENT_SHAPE field. The shape of each element will be defined as one of
     the following: rectangle (ELE_GEOM_REC), part of a ring (ELE_GEOM_RING_PART), part of an elliptical ring
     (ELE_GEOM_ELLIPSE_PART).
-  
+
     The size is provided through 6 parameters in ELEMENT_SIZE. These 6 parameters indicate the dimensions of each element
     according to their geometry, see [Figure 12](onde_ut_elements.md).
-  
+
     For ELE_GEOM_REC : DIM_X1, DIM_Y, 0.0, 0.0, 0.0, 0.0.
-  
+
     For ELE_GEOM_RING_PART: r, e, theta_min, theta_max, 0.0, 0.0
-  
+
     For ELE_GEOM_ELLIPSE_PART: r_X, e_X, r_Y, e_Y, theta_min, theta_max
-  
+
     ![Different types of element shape](../images/media/element_shapes.png "Figure 12")
-  
+
     *[Figure 12](onde_ut_elements.md): Different types of element shape*
-  
-    **Element positioning**
-  
+
+    #### Element positioning
+
     The ELEMENT_FRAME array defines the position and orientation of the probe elements defined by their frames in the PCF.
     For rectangular elements, x and y must be aligned with the main axes of the rectangle. For elliptical elements, x and y
     must be aligned with the major and the minor axes of the ellipse. For circular rings, x and y simply must be coplanar
     with the element. The frame should be orientated such that z is in the direction of ultrasonic emission (see [definition of frames](index.md#definition-of-frames)).
-  
-    **Element ordering convention**
-  
+
+    #### Element ordering convention
+
     For linear and matrix probes (see [Figure 13](onde_ut_elements.md)), the chosen convention is as follows : numbering according to the minor
     axis then according to the major axis, both in ascending order.
-  
+
     For annular, elliptical and bi-elliptical probes (see [Figure 13](onde_ut_elements.md)), the chosen convention is as follows : numbering from
     internal rings to external rings. On each ring, the numbering is done in ascending order in the direct direction around
     the Z axis of the probe, the origin being taken on the major axis.
-  
+
     For dual probes (see [Figure 14](onde_ut_elements.md)), the two probes have a symmetrical cutout. The right probe has elements from 1 to N
     following the numbering convention established previously. The left probe has elements from N+1 to 2N with a numbering
     symmetrical to that of the right probe according to the major axis.
-  
+
     ![Convention for element numbering](../images/media/element_numbering.png "Figure 13")
-  
+
     *[Figure 13](onde_ut_elements.md): Convention for element numbering*
-  
+
     ![Convention for dual probes element numbering](../images/media/dual_probes_element_numbering.png "Figure 14")
-  
+
     *[Figure 14](onde_ut_elements.md): Convention for dual probes element numbering*
 fields:
   FRAME:

--- a/class_definitions/onde_ut_law.yaml
+++ b/class_definitions/onde_ut_law.yaml
@@ -1,25 +1,16 @@
 onde_class: ONDE_UT_LAW
 inherits: []
-description: '### Law
-
-
-  For multielements, these groups describe the settings of a given transmit or receive
-  law. PROBE and ELEMENT give the
-
-  probe and element number to which the DELAY and WEIGHTING apply.
-
-
-  The format also allows to store an information about the corresponding ultrasonic
-  path.
-
-
-  PROPAGATION_LINE represents the ultrasonic ray along which the data is to be represented
-  in a true visualisation. It
-
-  contains at least two points in the Probe Coordinates Frame corresponding to the
-  start and end of the ray. (x,y,z)
-
-  positions in Probe Coordinate Frame and time of flight are stored.'
+description: |-
+    ### Law
+  
+    For multielements, these groups describe the settings of a given transmit or receive law. PROBE and ELEMENT give the
+    probe and element number to which the DELAY and WEIGHTING apply.
+  
+    The format also allows to store an information about the corresponding ultrasonic path.
+  
+    PROPAGATION_LINE represents the ultrasonic ray along which the data is to be represented in a true visualisation. It
+    contains at least two points in the Probe Coordinates Frame corresponding to the start and end of the ray. (x,y,z)
+    positions in Probe Coordinate Frame and time of flight are stored.
 fields:
   PROBE:
     full_name: ONDE_UT_LAW:PROBE

--- a/class_definitions/onde_ut_law.yaml
+++ b/class_definitions/onde_ut_law.yaml
@@ -2,12 +2,12 @@ onde_class: ONDE_UT_LAW
 inherits: []
 description: |-
     ### Law
-  
+
     For multielements, these groups describe the settings of a given transmit or receive law. PROBE and ELEMENT give the
     probe and element number to which the DELAY and WEIGHTING apply.
-  
+
     The format also allows to store an information about the corresponding ultrasonic path.
-  
+
     PROPAGATION_LINE represents the ultrasonic ray along which the data is to be represented in a true visualisation. It
     contains at least two points in the Probe Coordinates Frame corresponding to the start and end of the ray. (x,y,z)
     positions in Probe Coordinate Frame and time of flight are stored.

--- a/class_definitions/onde_ut_probe.yaml
+++ b/class_definitions/onde_ut_probe.yaml
@@ -2,63 +2,35 @@ onde_class: ONDE_UT_PROBE
 inherits: []
 accessories:
 - ONDE_UT_ELEMENTS
-description: '### Probes
-
-
-  **Probe representation**
-
-
-  The probe block of the data model accommodates two distinct levels of representation:
-  a very generic one that describes
-
-  the exact positions and shapes of the elements forming the transducer and another
-  one that more closely follows ordinary
-
-  technical specifications of the transducer in terms of transducer dimension, pitch,
-  shape, wedge dimensions, etc...
-
-
-  As indicated in the preamble, as for other matters, we have imposed the generic
-  representations and provide optionally
-
-  the possibility to have a more NDE-oriented description.
-
-
-  **Dual probes**
-
-
-  In the file format, when using the NDE-oriented description, dual probes are handled
-  as one PROBE block. When using only
-
-  the generic description, the freedom to define one or two blocks remains, as in
-  MFMC and ECUF formats.
-
-
-  **Frequencies**
-
-
-  In order to accommodate for advanced setups, we have chosen to give the possibility
-  to define one frequency per element.
-
-  A common usage will however be to have one frequency for all elements, and in this
-  case, it is possible to define an
-
-  array of size one with the frequency applied to all elements. The same possibility
-  to provide one value applied to all
-
-  elements is also provided for other fields related to elements except ELEMENT_POSITION.
-  The cardinality can thus either
-
-  be 1 or N.
-
-
-  **Surrounded and surrounding probes**
-
-
-  These can be defined by using the cylindrical FOCALISATION_SURFACE. A positive radius
-  will be used for surrounding
-
-  probes, a negative one for surrounded probes.'
+description: |-
+    ### Probes
+  
+    **Probe representation**
+  
+    The probe block of the data model accommodates two distinct levels of representation: a very generic one that describes
+    the exact positions and shapes of the elements forming the transducer and another one that more closely follows ordinary
+    technical specifications of the transducer in terms of transducer dimension, pitch, shape, wedge dimensions, etc...
+  
+    As indicated in the preamble, as for other matters, we have imposed the generic representations and provide optionally
+    the possibility to have a more NDE-oriented description.
+  
+    **Dual probes**
+  
+    In the file format, when using the NDE-oriented description, dual probes are handled as one PROBE block. When using only
+    the generic description, the freedom to define one or two blocks remains, as in MFMC and ECUF formats.
+  
+    **Frequencies**
+  
+    In order to accommodate for advanced setups, we have chosen to give the possibility to define one frequency per element.
+    A common usage will however be to have one frequency for all elements, and in this case, it is possible to define an
+    array of size one with the frequency applied to all elements. The same possibility to provide one value applied to all
+    elements is also provided for other fields related to elements except ELEMENT_POSITION. The cardinality can thus either
+    be 1 or N.
+  
+    **Surrounded and surrounding probes**
+  
+    These can be defined by using the cylindrical FOCALISATION_SURFACE. A positive radius will be used for surrounding
+    probes, a negative one for surrounded probes.
 fields:
   TYPE_TAGS:
     full_name: ONDE:TYPE_TAGS

--- a/class_definitions/onde_ut_probe.yaml
+++ b/class_definitions/onde_ut_probe.yaml
@@ -4,31 +4,31 @@ accessories:
 - ONDE_UT_ELEMENTS
 description: |-
     ### Probes
-  
-    **Probe representation**
-  
+
+    #### Probe representation
+
     The probe block of the data model accommodates two distinct levels of representation: a very generic one that describes
     the exact positions and shapes of the elements forming the transducer and another one that more closely follows ordinary
     technical specifications of the transducer in terms of transducer dimension, pitch, shape, wedge dimensions, etc...
-  
+
     As indicated in the preamble, as for other matters, we have imposed the generic representations and provide optionally
     the possibility to have a more NDE-oriented description.
-  
-    **Dual probes**
-  
+
+    #### Dual probes
+
     In the file format, when using the NDE-oriented description, dual probes are handled as one PROBE block. When using only
     the generic description, the freedom to define one or two blocks remains, as in MFMC and ECUF formats.
-  
-    **Frequencies**
-  
+
+    #### Frequencies
+
     In order to accommodate for advanced setups, we have chosen to give the possibility to define one frequency per element.
     A common usage will however be to have one frequency for all elements, and in this case, it is possible to define an
     array of size one with the frequency applied to all elements. The same possibility to provide one value applied to all
     elements is also provided for other fields related to elements except ELEMENT_POSITION. The cardinality can thus either
     be 1 or N.
-  
-    **Surrounded and surrounding probes**
-  
+
+    #### Surrounded and surrounding probes
+
     These can be defined by using the cylindrical FOCALISATION_SURFACE. A positive radius will be used for surrounding
     probes, a negative one for surrounded probes.
 fields:

--- a/class_definitions/onde_wedge.yaml
+++ b/class_definitions/onde_wedge.yaml
@@ -1,45 +1,67 @@
 onde_class: ONDE_WEDGE
 inherits:
 - ONDE_UT_COUPLING
-description: "**Wedge angles conventions**\n\nFor contact probes, wedge angles are\
-  \ defined according to this order of application (see [Figure 15](onde_wedge.md)):\n\
-  \n1. rotation of the incidence angle around the Y axis of the probe in the direct\
-  \ direction\n\n2. rotation of the skew angle around the new X axis of the probe\
-  \ in the direct direction\n\n3. rotation of the disorientation angle around the\
-  \ new Z axis in the direct direction\n\nFor dual probes, wedge angles are defined\
-  \ according to this order of application (see [Figure 15](onde_wedge.md)):\n\n1.\
-  \ rotation of the incidence angle around the Y axis of each probe in the direct\
-  \ direction\n\n2. rotation of the roof angle around the new X axis of each probe\
-  \ in the direct direction\n\n3. rotation of the disorientation angle around the\
-  \ new Z axis of each probe in the direct direction\n\n4. rotation of the squint\
-  \ angle around the new Z axis of each probe\n    - in the direct direction for the\
-  \ right probe\n    - in the indirect direction for the left probe.\n\n![Definition\
-  \ of wedge parameters for contact and dual probes](../images/media/wedge_parameters_contact_dual.png\
-  \ \"Figure 15\")\n\n*[Figure 15](onde_wedge.md): Definition of wedge parameters\
-  \ for contact and dual probes*\n\nThe definition of the index point for contact\
-  \ probes with planar and cylindrical wedges along the major and minor axis\nare\
-  \ given in [Figure 16](onde_wedge.md), [Figure 17](onde_wedge.md), [Figure 18](onde_wedge.md)\
-  \ respectively.\n\n![Definition of wedge parameters for contact planar probe](../images/media/wedge_parameters_contact_planar.png\
-  \ \"Figure 16\")\n\n*[Figure 16](onde_wedge.md): Definition of wedge parameters\
-  \ for contact planar probe*\n\n![Definition of wedge parameters for CYLINDRICAL_MAJOR\
-  \ contact probe](../images/media/wedge_parameters_cylindrical_major.png \"Figure\
-  \ 17\")\n\n*[Figure 17](onde_wedge.md): Definition of wedge parameters for CYLINDRICAL_MAJOR\
-  \ contact probe*\n\n![Definition of wedge parameters for CYLINDRICAL_MINOR contact\
-  \ probe](../images/media/wedge_parameters_cylindrical_minor.png \"Figure 18\")\n\
-  \n*[Figure 18](onde_wedge.md): Definition of wedge parameters for CYLINDRICAL_MINOR\
-  \ contact probe*\n\nThe definition of the index point for dual probes with planar\
-  \ and cylindrical wedges along the major and minor axis are\ngiven in [Figure 19](onde_wedge.md),\
-  \ [Figure 20](onde_wedge.md) and [Figure 21](onde_wedge.md) respectively.\n\n![Definition\
-  \ of wedge parameters for a dual planar probe](../images/media/wedge_parameters_dual_planar.png\
-  \ \"Figure 19\")\n\n*[Figure 19](onde_wedge.md): Definition of wedge parameters\
-  \ for a dual planar probe*\n\n![Definition of wedge parameters for CYLINDRICAL_MAJOR\
-  \ dual probe](../images/media/wedge_parameters_dual_cyl_major.png \"Figure 20\"\
-  )\n\n*[Figure 20](onde_wedge.md): Definition of wedge parameters for CYLINDRICAL_MAJOR\
-  \ dual probe*\n\n![Definition of wedge parameters for CYLINDRICAL_MINOR dual probe](../images/media/wedge_parameters_dual_cyl_minor.png\
-  \ \"Figure 21\")\n\n*[Figure 21](onde_wedge.md): Definition of wedge parameters\
-  \ for CYLINDRICAL_MINOR dual probe*\n\n**Velocities**\n\nAs for specimens, if both\
-  \ velocities (Longitudinal and shear) are not available, the missing one should\
-  \ be replaced by a\nNaN)."
+description: |-
+    **Wedge angles conventions**
+  
+    For contact probes, wedge angles are defined according to this order of application (see [Figure 15](onde_wedge.md)):
+  
+    1. rotation of the incidence angle around the Y axis of the probe in the direct direction
+  
+    2. rotation of the skew angle around the new X axis of the probe in the direct direction
+  
+    3. rotation of the disorientation angle around the new Z axis in the direct direction
+  
+    For dual probes, wedge angles are defined according to this order of application (see [Figure 15](onde_wedge.md)):
+  
+    1. rotation of the incidence angle around the Y axis of each probe in the direct direction
+  
+    2. rotation of the roof angle around the new X axis of each probe in the direct direction
+  
+    3. rotation of the disorientation angle around the new Z axis of each probe in the direct direction
+  
+    4. rotation of the squint angle around the new Z axis of each probe
+        - in the direct direction for the right probe
+        - in the indirect direction for the left probe.
+  
+    ![Definition of wedge parameters for contact and dual probes](../images/media/wedge_parameters_contact_dual.png "Figure 15")
+  
+    *[Figure 15](onde_wedge.md): Definition of wedge parameters for contact and dual probes*
+  
+    The definition of the index point for contact probes with planar and cylindrical wedges along the major and minor axis
+    are given in [Figure 16](onde_wedge.md), [Figure 17](onde_wedge.md), [Figure 18](onde_wedge.md) respectively.
+  
+    ![Definition of wedge parameters for contact planar probe](../images/media/wedge_parameters_contact_planar.png "Figure 16")
+  
+    *[Figure 16](onde_wedge.md): Definition of wedge parameters for contact planar probe*
+  
+    ![Definition of wedge parameters for CYLINDRICAL_MAJOR contact probe](../images/media/wedge_parameters_cylindrical_major.png "Figure 17")
+  
+    *[Figure 17](onde_wedge.md): Definition of wedge parameters for CYLINDRICAL_MAJOR contact probe*
+  
+    ![Definition of wedge parameters for CYLINDRICAL_MINOR contact probe](../images/media/wedge_parameters_cylindrical_minor.png "Figure 18")
+  
+    *[Figure 18](onde_wedge.md): Definition of wedge parameters for CYLINDRICAL_MINOR contact probe*
+  
+    The definition of the index point for dual probes with planar and cylindrical wedges along the major and minor axis are
+    given in [Figure 19](onde_wedge.md), [Figure 20](onde_wedge.md) and [Figure 21](onde_wedge.md) respectively.
+  
+    ![Definition of wedge parameters for a dual planar probe](../images/media/wedge_parameters_dual_planar.png "Figure 19")
+  
+    *[Figure 19](onde_wedge.md): Definition of wedge parameters for a dual planar probe*
+  
+    ![Definition of wedge parameters for CYLINDRICAL_MAJOR dual probe](../images/media/wedge_parameters_dual_cyl_major.png "Figure 20")
+  
+    *[Figure 20](onde_wedge.md): Definition of wedge parameters for CYLINDRICAL_MAJOR dual probe*
+  
+    ![Definition of wedge parameters for CYLINDRICAL_MINOR dual probe](../images/media/wedge_parameters_dual_cyl_minor.png "Figure 21")
+  
+    *[Figure 21](onde_wedge.md): Definition of wedge parameters for CYLINDRICAL_MINOR dual probe*
+  
+    **Velocities**
+  
+    As for specimens, if both velocities (Longitudinal and shear) are not available, the missing one should be replaced by a
+    NaN).
 fields:
   LABEL:
     full_name: ONDE:LABEL

--- a/class_definitions/onde_wedge.yaml
+++ b/class_definitions/onde_wedge.yaml
@@ -2,64 +2,64 @@ onde_class: ONDE_WEDGE
 inherits:
 - ONDE_UT_COUPLING
 description: |-
-    **Wedge angles conventions**
-  
+    #### Wedge angles conventions
+
     For contact probes, wedge angles are defined according to this order of application (see [Figure 15](onde_wedge.md)):
-  
+
     1. rotation of the incidence angle around the Y axis of the probe in the direct direction
-  
+
     2. rotation of the skew angle around the new X axis of the probe in the direct direction
-  
+
     3. rotation of the disorientation angle around the new Z axis in the direct direction
-  
+
     For dual probes, wedge angles are defined according to this order of application (see [Figure 15](onde_wedge.md)):
-  
+
     1. rotation of the incidence angle around the Y axis of each probe in the direct direction
-  
+
     2. rotation of the roof angle around the new X axis of each probe in the direct direction
-  
+
     3. rotation of the disorientation angle around the new Z axis of each probe in the direct direction
-  
+
     4. rotation of the squint angle around the new Z axis of each probe
         - in the direct direction for the right probe
         - in the indirect direction for the left probe.
-  
+
     ![Definition of wedge parameters for contact and dual probes](../images/media/wedge_parameters_contact_dual.png "Figure 15")
-  
+
     *[Figure 15](onde_wedge.md): Definition of wedge parameters for contact and dual probes*
-  
+
     The definition of the index point for contact probes with planar and cylindrical wedges along the major and minor axis
     are given in [Figure 16](onde_wedge.md), [Figure 17](onde_wedge.md), [Figure 18](onde_wedge.md) respectively.
-  
+
     ![Definition of wedge parameters for contact planar probe](../images/media/wedge_parameters_contact_planar.png "Figure 16")
-  
+
     *[Figure 16](onde_wedge.md): Definition of wedge parameters for contact planar probe*
-  
+
     ![Definition of wedge parameters for CYLINDRICAL_MAJOR contact probe](../images/media/wedge_parameters_cylindrical_major.png "Figure 17")
-  
+
     *[Figure 17](onde_wedge.md): Definition of wedge parameters for CYLINDRICAL_MAJOR contact probe*
-  
+
     ![Definition of wedge parameters for CYLINDRICAL_MINOR contact probe](../images/media/wedge_parameters_cylindrical_minor.png "Figure 18")
-  
+
     *[Figure 18](onde_wedge.md): Definition of wedge parameters for CYLINDRICAL_MINOR contact probe*
-  
+
     The definition of the index point for dual probes with planar and cylindrical wedges along the major and minor axis are
     given in [Figure 19](onde_wedge.md), [Figure 20](onde_wedge.md) and [Figure 21](onde_wedge.md) respectively.
-  
+
     ![Definition of wedge parameters for a dual planar probe](../images/media/wedge_parameters_dual_planar.png "Figure 19")
-  
+
     *[Figure 19](onde_wedge.md): Definition of wedge parameters for a dual planar probe*
-  
+
     ![Definition of wedge parameters for CYLINDRICAL_MAJOR dual probe](../images/media/wedge_parameters_dual_cyl_major.png "Figure 20")
-  
+
     *[Figure 20](onde_wedge.md): Definition of wedge parameters for CYLINDRICAL_MAJOR dual probe*
-  
+
     ![Definition of wedge parameters for CYLINDRICAL_MINOR dual probe](../images/media/wedge_parameters_dual_cyl_minor.png "Figure 21")
-  
+
     *[Figure 21](onde_wedge.md): Definition of wedge parameters for CYLINDRICAL_MINOR dual probe*
-  
-    **Velocities**
-  
+
+    #### Velocities
+
     As for specimens, if both velocities (Longitudinal and shear) are not available, the missing one should be replaced by a
     NaN).
 fields:

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -116,7 +116,7 @@ Definitions (derived from MFMC 2.0.0b specification)
 | N_U\<m\>      | Number of acquisition positions in the U direction for the m-th dataset  | 
 | N_V\<m\>      | Number of acquisition positions in the V direction for the m-th dataset  |
 
-Note : if N_U and N_V are defined (grid-like acquisition), N_DF\<m\> = N_U\<m\> x N_V\<m\>
+Note : N_DF\<m\> = N_U\<m\> x N_V\<m\>
 
 ## Data Model
 


### PR DESCRIPTION
Duplicate of #59 targetting [next_minor](https://github.com/COFREND/ONDE-format/tree/next_minor).

Checked: do not have any effect on the generated documentation

I did not re-check the generated documentation, because the diffs between [main](https://github.com/COFREND/ONDE-format/tree/main) and [next_minor](https://github.com/COFREND/ONDE-format/tree/next_minor) are not significant:
```patch
❯ jj diff -f main@cofrend -t next_minor@cofrend --color=never --git 
diff --git a/README.md b/README.md
index 33e013423c..80281368ef 100644
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@
 
 The present repository contains the Single Source of Truth (SSOT) for the data model in the `class_definitions/` directory. The specification is defined through a series of YAML files. Each YAML file contains both the machine-readable metadata defining the HDF5 structure as well as the human-readable Markdown narrative explaining the concepts.
 
-The human-readable version resulting from this SSOT is available here : https://cofrend.github.io/ONDE-format/ .
-This version of the specification is the latest one available. 
-
-At this stage, only ultrasound testing is considered.
 It will be completed in the future by an extension to Eddy Current testing and by python tools allowing to check the compliance of a file to the specification.
 
 ## Local Documentation Rendering
diff --git a/class_definitions/onde_ut.yaml b/class_definitions/onde_ut.yaml
index 33aae55b75..8af32e6e7e 100644
--- a/class_definitions/onde_ut.yaml
+++ b/class_definitions/onde_ut.yaml
@@ -59,4 +59,4 @@
     hdf5_type: H5T_STRING
     description: ''
     dimensions: '1'
-    allowed_values: '"0.9.0"'
+    allowed_values: '"0.9.1"'
diff --git a/specification/overview.md b/specification/overview.md
index 0c3e176fa6..da186b7ea6 100644
--- a/specification/overview.md
+++ b/specification/overview.md
@@ -1,4 +1,4 @@
-# Open NDE File Format specification - Version 0.9.0
+# Open NDE File Format specification - Version 0.9.1
 
 <img src="../images/media/COFREND_EPRI_banner.png" alt="drawing" width="400"/>
```

I’ll further edit this PR, taking those [remarks](https://github.com/COFREND/ONDE-format/pull/59#issuecomment-4951714967) into account, and maybe also merging #61.
