### PR TITLE
Generate robots.txt to prevent LLM indexing of PR previews

### DIFF
--- a/tools/generate_docs.py
+++ b/tools/generate_docs.py
@@ -169,7 +169,11 @@ def main():
     processHtmlClass: "arithmatex"
   }
 };''')
-    
+
+    # Add robots.txt to prevent indexing of PR previews
+    with open(os.path.join(docs_dir, 'robots.txt'), 'w') as f:
+        f.write("User-agent: *\nDisallow: /pr-preview/\n")
+
     # Custom CSS for tighter tables
     css_dir = os.path.join(docs_dir, 'stylesheets')
     os.makedirs(css_dir, exist_ok=True)


### PR DESCRIPTION
This PR resolves #75 by automatically generating a robots.txt file to prevent search engines from crawling pull request previews.