### PR TITLE
Compiled CSV Centrally Accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ The documentation is built using MkDocs. You can render it locally using the pro
 
 The generated documentation site will be available in the `build/docs/site/` directory.
 
-## Legacy CSV Generation
+## CSV Export for Automated Tooling
 
-While the Single Source of Truth is defined using the YAML schemas in `class_definitions/`, you may occasionally need the legacy CSV format for compatibility with older tooling. 
+While the Single Source of Truth for the specification is defined using the individual YAML files in the `class_definitions/` directory, navigating multiple YAML files can become cumbersome for quick import or validation purposes in automated tooling.
 
-You can download the generated CSV file directly from the documentation site here: [ONDE_fields.csv](ONDE_fields.csv).
+For simplified use in these scenarios, we provide a unified CSV export of the data model. You can download the latest generated CSV file directly from the documentation site here: [https://COFREND.github.io/ONDE-format/ONDE_fields.csv](https://COFREND.github.io/ONDE-format/ONDE_fields.csv).
 
 You can also generate the CSV file manually at any time by running:
 ```bash

--- a/README.md
+++ b/README.md
@@ -33,14 +33,16 @@ The generated documentation site will be available in the `build/docs/site/` dir
 
 ## Legacy CSV Generation
 
-While the Single Source of Truth is defined using the YAML schemas in `class_definitions/`, you may occasionally need the legacy CSV format for compatibility with older tooling.
+While the Single Source of Truth is defined using the YAML schemas in `class_definitions/`, you may occasionally need the legacy CSV format for compatibility with older tooling. 
 
-You can generate the CSV file at any time by running:
+You can download the generated CSV file directly from the documentation site here: [ONDE_fields.csv](ONDE_fields.csv).
+
+You can also generate the CSV file manually at any time by running:
 ```bash
 python tools/generate_csv.py
 ```
 
-The generated CSV file will be available at `build/ONDE_fields.csv`.
+The generated CSV file will be available at `build/ONDE_fields.csv` locally.
 
 ## Instructions for contributors
 

--- a/specification/data_model.md
+++ b/specification/data_model.md
@@ -4,7 +4,7 @@
 The ONDE Data Model is defined by classes, which group together named fields. When implemented in the ONDE file, these classes translate into HDF5 groups. This section of the documentation describes:
 
 - the principles used to define the classes (including subclasses and accessory classes) and the fields in the data model,
-- the transcription of this data model in the reference csv file (see [ONDE_fields.csv](ONDE_fields.csv)),
+- the transcription of this data model in the reference csv file (see [ONDE_fields.csv](ONDE_fields.csv)). This CSV file is provided for simplified use in automated tooling where the individual YAML files may become too cumbersome for quick import or validation purposes.
 - the way in which this data model translates into an HDF5 implementation in the ONDE file.
 
 

--- a/specification/data_model.md
+++ b/specification/data_model.md
@@ -4,7 +4,7 @@
 The ONDE Data Model is defined by classes, which group together named fields. When implemented in the ONDE file, these classes translate into HDF5 groups. This section of the documentation describes:
 
 - the principles used to define the classes (including subclasses and accessory classes) and the fields in the data model,
-- the transcription of this data model in the reference csv file (see https://github.com/COFREND/ONDE-format/blob/main/ONDE_fields/ONDE_fields.csv),
+- the transcription of this data model in the reference csv file (see [ONDE_fields.csv](ONDE_fields.csv)),
 - the way in which this data model translates into an HDF5 implementation in the ONDE file.
 
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -59,6 +59,8 @@
 - All quantities are defined with SI units. Units are therefore expressed in meters, kilograms,
   seconds. However, degrees are used instead of radians.
 
+- The formal Single Source of Truth for the data model is defined via YAML files, which are compiled to generate this documentation. A unified CSV export is also provided (see [ONDE_fields.csv](ONDE_fields.csv)). This CSV file is provided for simplified use in automated tooling where the individual YAML files may become too cumbersome for quick import or validation purposes.
+
 ## Tables legend
 
 In the following sections, the data structure is described by blocks presented in tables.

--- a/tools/generate_csv.py
+++ b/tools/generate_csv.py
@@ -9,9 +9,8 @@ def parse_yaml(filepath):
     with open(filepath, 'r', encoding='utf-8') as f:
         return yaml.safe_load(f)
 
-def generate_csv():
+def generate_csv(output_csv='build/ONDE_fields.csv'):
     input_dir = 'class_definitions'
-    output_csv = 'build/ONDE_fields.csv'
     
     os.makedirs(os.path.dirname(output_csv), exist_ok=True)
     

--- a/tools/generate_docs.py
+++ b/tools/generate_docs.py
@@ -18,6 +18,7 @@ import yaml
 import glob
 import shutil
 import subprocess
+import generate_csv
 
 try:
     from pydantic import BaseModel, ValidationError
@@ -152,6 +153,10 @@ def main():
     
     docs_dir = os.path.join(output_dir, 'docs')
     os.makedirs(docs_dir, exist_ok=True)
+    
+    # Generate CSV to the root of the site
+    csv_output = os.path.join(docs_dir, 'ONDE_fields.csv')
+    generate_csv.generate_csv(csv_output)
     
     # Enable Math rendering via MathJax
     js_dir = os.path.join(docs_dir, 'javascripts')


### PR DESCRIPTION
This resolves #73 by ensuring that the CSV file is placed alongside the rendered documentation for quick download.  Links are added in several locations for quick reference.