### PR TITLE
Issues #34 and #50 - clarifying the relationship between Cscan datase…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ The documentation is built using MkDocs. You can render it locally using the pro
 
 The generated documentation site will be available in the `build/docs/site/` directory.
 
-## Legacy CSV Generation
+## CSV Export for Automated Tooling
 
-While the Single Source of Truth is defined using the YAML schemas in `class_definitions/`, you may occasionally need the legacy CSV format for compatibility with older tooling. 
+While the Single Source of Truth for the specification is defined using the individual YAML files in the `class_definitions/` directory, navigating multiple YAML files can become cumbersome for quick import or validation purposes in automated tooling.
 
-You can download the generated CSV file directly from the documentation site here: [ONDE_fields.csv](ONDE_fields.csv).
+For simplified use in these scenarios, we provide a unified CSV export of the data model. You can download the latest generated CSV file directly from the documentation site here: [https://COFREND.github.io/ONDE-format/ONDE_fields.csv](https://COFREND.github.io/ONDE-format/ONDE_fields.csv).
 
 You can also generate the CSV file manually at any time by running:
 ```bash

--- a/README.md
+++ b/README.md
@@ -33,14 +33,16 @@ The generated documentation site will be available in the `build/docs/site/` dir
 
 ## Legacy CSV Generation
 
-While the Single Source of Truth is defined using the YAML schemas in `class_definitions/`, you may occasionally need the legacy CSV format for compatibility with older tooling.
+While the Single Source of Truth is defined using the YAML schemas in `class_definitions/`, you may occasionally need the legacy CSV format for compatibility with older tooling. 
 
-You can generate the CSV file at any time by running:
+You can download the generated CSV file directly from the documentation site here: [ONDE_fields.csv](ONDE_fields.csv).
+
+You can also generate the CSV file manually at any time by running:
 ```bash
 python tools/generate_csv.py
 ```
 
-The generated CSV file will be available at `build/ONDE_fields.csv`.
+The generated CSV file will be available at `build/ONDE_fields.csv` locally.
 
 ## Instructions for contributors
 

--- a/class_definitions/onde_2dcad.yaml
+++ b/class_definitions/onde_2dcad.yaml
@@ -29,6 +29,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Specifies the type of 2D extrusion, either PLANE or CYLINDER.'
     description: ''
     dimensions: '1'
     allowed_values: '"PLANE"|"CYLINDER"'
@@ -37,6 +38,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Defines the extrusion length for planar extrusions or the diameter for cylindrical extrusions.'
     description: ''
     dimensions: '1'
   CAD:
@@ -44,5 +46,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Contains the 2D CAD representation of the component, formatted as a DXF file.'
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_3dcad.yaml
+++ b/class_definitions/onde_3dcad.yaml
@@ -8,5 +8,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: "A 3D CAD representation of the component."
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_acquisition_grid.yaml
+++ b/class_definitions/onde_acquisition_grid.yaml
@@ -38,6 +38,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_COMPONENT>
+    short_description: The reference specimen associated with the acquisition grid.
     description: When defining an acquisition grid, it is necessary to define a reference
       specimen that is either a cylinder or a plane.
     dimensions: '1'
@@ -46,6 +47,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: Specifies whether the grid is on the inner or outer surface.
     description: Defines whether the grid is expressed in the inner surface of the
       cylinder or on the outer surface
     allowed_values: '"INNER"|"OUTER"'
@@ -54,6 +56,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: The 2D coordinate frame defining the encoding directions on the surface.
     description: 2D Frame defining the U_GRID and V_GRID directions of the encoding
       in the surface representation of the specimen (X,Y) for planar specimens, (X,THETA)
       for cylindrical specimens. (1,0,) is assumed if missing
@@ -63,6 +66,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: The targeted grid positions along the first axis (U).
     description: The specified values of the first coder at the different positions
     dimensions: '[N_U<m>]'
   V_GRID_DATA:
@@ -70,6 +74,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: The targeted grid positions along the second axis (V).
     description: The specified values of the second coder at the different positions.
       If missing while U_GRID_DATA is present, 1D array of data is assumed.
     dimensions: '[N_V<m>]'
@@ -78,6 +83,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: Indicates the scanning pattern used for the acquisition grid.
     description: |-
       Defines whether the data is ordered in the same direction for each scan
       (COMB) or is inversed every second scan (RASTER)
@@ -88,6 +94,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: The actual measured encoder values along the U axis.
     description: Obtained encoder values on the u axis
     dimensions: '[N_V<m>,N_U<m>]'
   V_ENCODER:
@@ -95,6 +102,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: The actual measured encoder values along the V axis.
     description: Obtained encoder values on the v axis
     dimensions: '[N_V<m>,N_U<m>]'
   PROBE_DIRECTION:
@@ -102,6 +110,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: The orientation of the probe within the grid's local coordinate system.
     description: |-
       For grid data, direction of the probe in the (u, v, w) coordinate system.
       Defaults to identity matrix.

--- a/class_definitions/onde_component.yaml
+++ b/class_definitions/onde_component.yaml
@@ -91,19 +91,22 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: A human-readable label or name for the component.
     description: ''
   VELOCITIES:
     full_name: ONDE_COMPONENT:VELOCITIES
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
-    description: ''
+    short_description: Longitudinal and shear wave velocities of the component.
+    description: 'The two values indicate the longitudinal and shear wave velocities respectively. Missing values should be replaced by NaN.'
     dimensions: '[2]'
   DENSITY:
     full_name: ONDE_COMPONENT:DENSITY
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: Density of the component material.
     description: ''
     dimensions: '1'
   VISUALIZATION_CAD:
@@ -111,6 +114,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: Optional CAD file used for visualization purposes.
     description: Optional CAD used for visualisation purposes
     dimensions: '1'
   VISUALIZATION_CAD_FRAME:
@@ -118,6 +122,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: Transformation frame for the visualization CAD.
     description: |-
       Definition of the frame defining the visualisation CAD with offset and
       quaternions in the specimen frame- Identity is used if absent
@@ -127,6 +132,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: Transformation defining the component's frame relative to the global reference.
     description: |-
       Definition of the specimen frame in the reference frame. If not provided,
       default value is identity with the reference frame.
@@ -136,6 +142,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: Additional text comment regarding the component.
     description: ''
     dimensions: '1'
   IMAGE:
@@ -143,5 +150,6 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: Image parameters or data associated with the component.
     description: ''
     dimensions: '[3]'

--- a/class_definitions/onde_computation.yaml
+++ b/class_definitions/onde_computation.yaml
@@ -1,0 +1,12 @@
+onde_class: ONDE_COMPUTATION
+inherits: []
+description: |-
+
+    ### Computation
+
+    The ONDE_COMPUTATION class is used to describe the computation of a dataset
+    from other datasets. It is used to describe the computation of a dataset
+    from other datasets, for example the computation of a CScan from Ascan data.
+
+fields: {}
+  

--- a/class_definitions/onde_cylinder.yaml
+++ b/class_definitions/onde_cylinder.yaml
@@ -18,5 +18,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Specifies the dimensions of the cylinder. It is a triplet containing the outer diameter, thickness, and length.'
     description: ''
     dimensions: '[3]'

--- a/class_definitions/onde_dataset.yaml
+++ b/class_definitions/onde_dataset.yaml
@@ -39,6 +39,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: A name or label representing this dataset.
     description: A name for this dataset
     dimensions: '1'
   SETUP:
@@ -46,6 +47,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_SETUP>
+    short_description: Reference to the setup configuration used for this dataset.
     description: ''
     dimensions: '1'
   OPERATOR:
@@ -53,6 +55,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: The name or identifier of the operator conducting the acquisition.
     description: ''
     dimensions: '1'
   DATE_AND_TIME:
@@ -60,6 +63,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: The date and time of the data acquisition.
     description: ''
     dimensions: '1'
   DATA:
@@ -67,6 +71,7 @@ fields:
     required: false
     storage: A or D
     hdf5_type: H5T_STD_REF_OBJ<data> or H5T_INTEGER or H5T_FLOAT
+    short_description: The core data array or a reference to the array.
     description: |-
       Data can be either an array or a reference to an array. Omitting this
       field is possible, in the event when Tscan or Cscan data is recorded but
@@ -77,6 +82,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_DIMENSION>
+    short_description: Reference to the dimension defining the amplitude characteristics.
     description: |-
       If absent, treated as coordinate "Amplitude", units "Arbitrary", offset
       0.0, scale 1.0
@@ -86,6 +92,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_DIMENSION>
+    short_description: Array of references to the index dimensions of the dataset.
     description: |-
       One entry per dimension of ONDE_DATASET:DATA. Any that are absent are
       treated as coordinate "Time", units "seconds", offset 0.0, scale 1.0

--- a/class_definitions/onde_dataset.yaml
+++ b/class_definitions/onde_dataset.yaml
@@ -5,8 +5,7 @@ description: |
 
   ### Generic remarks on datasets
 
-  The DATE_AND_TIME and OPERATOR fields allow to give indication on the context of the acquisition. For DATE_AND_TIME the
-  ISO 8601 extended format: 'yyyy-mm-dd HH:MM:SS' (e.g. '2019-01-16 17:05:06') must be used.
+  The DATE_AND_TIME and OPERATOR fields allow to give indication on the context of the acquisition. 
 
   ### Notes on groups
 
@@ -60,11 +59,14 @@ fields:
     dimensions: '1'
   DATE_AND_TIME:
     full_name: ONDE_DATASET:DATE_AND_TIME
-    required: false
+    required: true
     storage: attribute
     hdf5_type: H5T_STRING
-    short_description: The date and time of the data acquisition.
-    description: ''
+    description: |-
+      The ISO 8601 extended format: 'yyyy-mm-ddTHH:MM:SS' (e.g. '2019-01-16T17:05:06') must be used with a capital T separating the date and the time. Optionally, a decimal point ('.') and a fractional portion of a second may be appended. In addition, time zone information is usually appended:
+      * "Z", indicating a timestamp in UTC
+      * "±hh:mm", indicating a timezone with the specified offset from UTC
+      * (no timezone information), indicating an unknown timezone; software will usually interpret this as local time or UTC. 
     dimensions: '1'
   DATA:
     full_name: ONDE_DATASET:DATA

--- a/class_definitions/onde_dataset_ut_ascan.yaml
+++ b/class_definitions/onde_dataset_ut_ascan.yaml
@@ -16,6 +16,7 @@ fields:
     required: false
     storage: A or D
     hdf5_type: H5T_STD_REF_OBJ<data> or H5T_INTEGER or H5T_FLOAT
+    short_description: "Contains the time signal data array or a reference to it."
     description: |-
       Data can be either an array or a reference to an array. Omitting this
       field is possible, in the event when Tscan or Cscan data is recorded but

--- a/class_definitions/onde_dataset_ut_cscan.yaml
+++ b/class_definitions/onde_dataset_ut_cscan.yaml
@@ -69,6 +69,7 @@ fields:
     required: true
     storage: A or D
     hdf5_type: H5T_STD_REF_OBJ<data> or H5T_INTEGER or H5T_FLOAT
+    short_description: References to arrays containing scalar raw data or data resulting from analysis of signals.
     description: references to arrays containing the different values stored in the
       dataset
     dimensions: '[N_CS<m>] |[N_CS<m>,N_Gate<m>]'
@@ -77,6 +78,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_STRING
+    short_description: A string defining the nature of the stored data, such as a custom property or a standardized name.
     description: |-
       string defining the stored data - the name can be either custom
       (MY_MATERIAL_PROPERTY for instance) or a standardized name: THICKNESS,
@@ -87,6 +89,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_ASCAN_DATASET> or H5T_STD_REF_OBJ<ONDE_UT_TSCAN_DATASET>
+    short_description: A reference to the dataset containing the originating underlying raw data.
     description: reference to the dataset containing the underlying data
     dimensions: '1'
   UNDERLYING_DATA_REFERENCE:
@@ -94,6 +97,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_INTEGER
+    short_description: A mapping that provides the correspondence between the C-scan scalar data and its originating scan.
     description: |-
       Correspondancy between the C-Scan scalar data and the scan originating.
       For a A-Scan, the scan is expressed in terms of (dataframe, law). For a 2D
@@ -105,6 +109,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_ACQUISITION_GRID>
+    short_description: A reference to a grid-type trajectory block used to position the C-scan data.
     description: ''
     dimensions: '1'
   GATES:
@@ -112,5 +117,6 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_GATE>
+    short_description: References to separate gate groups that define the time windows and thresholds used for data acquisition.
     description: ''
     dimensions: '[N_Gate<m>]'

--- a/class_definitions/onde_dataset_ut_cscan.yaml
+++ b/class_definitions/onde_dataset_ut_cscan.yaml
@@ -4,27 +4,15 @@ inherits:
 description: |+
     ### CScan datasets and gates
 
-    #### CScan data and peaks
+    #### CScan data 
 
-    While this Cscan dataset is mostly meant for the storage of peak-like data
-    (amplitude, time of flight, etc…) it is more generic and can accommodate
-    different values. DATA contains a vector of references to datasets containing scalar raw
-    data. The size of the data can be either N_DF<m> × N_Ascan<m> arrays
-    (for data resulting from analysis of signals) or N_DF<m> arrays (for encoder
+    CScan datasets are the entry points for the description of data that is
+    stored as scalar values. The data can come either from Ascan or Tscan data
+    through an extraction process. The extraction process is described in the 
+    ONDE_UT_EXTRACTION block. 
+    The size of the data can be either N_U<m> × N_V<m> x N_Ascan<m> arrays
+    (for data resulting from analysis of signals) or N_U<m> x N_V<m> arrays (for encoder
     data or data resulting from Tscan or monoelement scans).
-
-    #### Data description
-
-    The DATATYPE field contains a name defining the nature of the data —the name
-    can be either custom (MY_MATERIAL_PROPERTY for instance) or a standardized
-    name: THICKNESS, TIME_OF_FLIGHT, DEPTH, AMAX.
-
-    #### Data numbering
-
-    To be efficient for relatively small amounts of data, as opposed to other
-    blocks, the Cscan block allows for the handling of several data inside the
-    block. The DATA, DATA_TYPE vectors must have the same length and be ordered
-    coherently.
 
     #### Data positioning
 
@@ -40,29 +28,15 @@ description: |+
     2D Tscan, it will be (dataframe, column), for a 3D Tscan, it will be
     (dataframe, plane, column).
 
-    #### Gates
+    #### Gates and extractions
 
-    The gates are stored as a separate group of type ONDE_UT_GATE. The gates are
-    referenced in the ONDE_DATASET_UT_CSCAN group via the
-    ONDE_DATASET_UT_CSCAN:GATES field.  The gates used for the acquisition are
-    defined through five parameters. GATE_START and GATE_WIDTH define the time
-    window and GATE_THRESHOLD defines the threshold that was used to trigger the
-    storage of the data. GATE_DETECTION defines the type of triggering event
-    that was used to define the gate. GATE_POLARITY defines the mode that was
-    used for the detection (absolute, positive or negative). The following
-    figure defines the modes that can be used for detection. The numbers on the
-    figure correspond to the different triggering events. The correspondence
-    between these figures and the values allowed for GATE_DETECTION is the
-    following:
+    The gates are stored as a separate group of type ONDE_UT_GATE. 
+    The extraction process explaining how the Cscan data is obtained from the underlying data is described in the
+    ONDE_UT_EXTRACTION block. The extraction can be either a scalar value or an enumeration. The extraction relates to list of *ONDE_UT_GATE*, called
+    GATE_LIST which can be of size 1 or 2 : 1. If the list is of size 1,  the gate defines the time window for 
+    the extraction. 2. If the list is of size 2,  the extracted value is the difference between the two extractions, each defined by a gate. The nature of  
+    the extraction  can be either *TIME_OF_FLIGHT*, *AMPLITUDE*, *DEPTH* or *ALARM*. 
 
-    1. FIRST_FLANK
-    2. FIRST_PEAK
-    3. MAX_FLANK
-    4. MAX_PEAK
-    5. LAST_PEAK
-    6. LAST_FLANK
-
-    ![Detection modes for UT gates](../images/media/gate_detection.png)
 fields:
   DATA:
     full_name: ONDE_DATASET:DATA
@@ -71,17 +45,7 @@ fields:
     hdf5_type: H5T_STD_REF_OBJ<data> or H5T_INTEGER or H5T_FLOAT
     description: references to arrays containing the different values stored in the
       dataset
-    dimensions: '[N_CS<m>] |[N_CS<m>,N_Gate<m>]'
-  DATATYPE:
-    full_name: ONDE_DATASET_UT_CSCAN:DATATYPE
-    required: true
-    storage: dataset
-    hdf5_type: H5T_STRING
-    description: |-
-      string defining the stored data - the name can be either custom
-      (MY_MATERIAL_PROPERTY for instance) or a standardized name: THICKNESS,
-      TIME_OF_FLIGHT, DEPTH, AMAX
-    dimensions: '[N_CS<m>]'
+    dimensions: '1 or [N_U<m>,N_V<m>] or [N_U<m>,N_V<m>,N_A<m>]'
   UNDERLYING_DATA:
     full_name: ONDE_DATASET_UT_CSCAN:UNDERLYING_DATA
     required: false
@@ -107,10 +71,12 @@ fields:
     hdf5_type: H5T_STD_REF_OBJ<ONDE_ACQUISITION_GRID>
     description: ''
     dimensions: '1'
-  GATES:
-    full_name: ONDE_DATASET_UT_CSCAN:GATES
+  EXTRACTION:
+    full_name: ONDE_DATASET_UT_CSCAN:ONDE_UT_EXTRACTION
     required: false
-    storage: dataset
-    hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_GATE>
-    description: ''
-    dimensions: '[N_Gate<m>]'
+    storage: attribute
+    hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_EXTRACTION>
+    description: |- 
+      The referenced object describes the extraction process that was used 
+      to obtain the Cscan data from the underlying data.
+    dimensions: '1'

--- a/class_definitions/onde_dataset_ut_cscan.yaml
+++ b/class_definitions/onde_dataset_ut_cscan.yaml
@@ -2,30 +2,20 @@ onde_class: ONDE_DATASET_UT_CSCAN
 inherits:
 - ONDE_DATASET_UT
 description: |+
-    ### CScan datasets and gates
+    ### CScan datasets
 
-    #### CScan data and peaks
-
-    While this Cscan dataset is mostly meant for the storage of peak-like data
-    (amplitude, time of flight, etc…) it is more generic and can accommodate
-    different values. DATA contains a vector of references to datasets containing scalar raw
-    data. The size of the data can be either N_DF<m> × N_Ascan<m> arrays
-    (for data resulting from analysis of signals) or N_DF<m> arrays (for encoder
-    data or data resulting from Tscan or monoelement scans).
-
-    #### Data description
-
-    The DATATYPE field contains a name defining the nature of the data —the name
-    can be either custom (MY_MATERIAL_PROPERTY for instance) or a standardized
-    name: THICKNESS, TIME_OF_FLIGHT, DEPTH, AMAX.
-
-    #### Data numbering
-
-    To be efficient for relatively small amounts of data, as opposed to other
-    blocks, the Cscan block allows for the handling of several data inside the
-    block. The DATA, DATA_TYPE vectors must have the same length and be ordered
-    coherently.
-
+    CScan datasets are the entry points for the description of data that is
+    stored as scalar values. The data can come either from Ascan or Tscan data
+    through an extraction process. The extraction process is described in the 
+    ONDE_UT_EXTRACTION block. 
+    The size of the data can be either N_U<m> x N_V<m> x N_Ascan<m> arrays
+    (for data resulting from multiple scans at each point) or N_U<m> x N_V<m> 
+    arrays (for data resulting from monoelement scans). The data is
+     always stored in a 3-dimensional dataset of dimensions [N_U<m>, N_V<m>, N_Ascan<m>].
+     In the monoelement case, the third dimension is of size 1. 
+    The data is positioned through a trajectory block which is of grid type
+     and is referenced by the CSCAN_GRID attribute.
+     
     #### Data positioning
 
     The Cscan data must be positioned through a trajectory block which is of
@@ -40,50 +30,27 @@ description: |+
     2D Tscan, it will be (dataframe, column), for a 3D Tscan, it will be
     (dataframe, plane, column).
 
-    #### Gates
+    #### Gates and extractions
 
-    The gates are stored as a separate group of type ONDE_UT_GATE. The gates are
-    referenced in the ONDE_DATASET_UT_CSCAN group via the
-    ONDE_DATASET_UT_CSCAN:GATES field.  The gates used for the acquisition are
-    defined through five parameters. GATE_START and GATE_WIDTH define the time
-    window and GATE_THRESHOLD defines the threshold that was used to trigger the
-    storage of the data. GATE_DETECTION defines the type of triggering event
-    that was used to define the gate. GATE_POLARITY defines the mode that was
-    used for the detection (absolute, positive or negative). The following
-    figure defines the modes that can be used for detection. The numbers on the
-    figure correspond to the different triggering events. The correspondence
-    between these figures and the values allowed for GATE_DETECTION is the
-    following:
+    The gates are stored as a separate group of type ONDE_UT_GATE. 
+    The extraction process explaining how the Cscan data is obtained from the underlying data is described in the
+    ONDE_UT_EXTRACTION block. The extraction can be either a scalar value or an enumeration. The extraction relates to list of *ONDE_UT_GATE*, called
+    GATE_LIST which can be of size 1 or 2 : 1. If the list is of size 1,  the gate defines the time window for 
+    the extraction. 2. If the list is of size 2,  the extracted value is the difference between the two extractions, each defined by a gate. The nature of  
+    the extraction  can be either *TIME_OF_FLIGHT*, *AMPLITUDE*, *DEPTH* or *ALARM*. 
 
-    1. FIRST_FLANK
-    2. FIRST_PEAK
-    3. MAX_FLANK
-    4. MAX_PEAK
-    5. LAST_PEAK
-    6. LAST_FLANK
-
-    ![Detection modes for UT gates](../images/media/gate_detection.png)
 fields:
   DATA:
     full_name: ONDE_DATASET:DATA
     required: true
     storage: A or D
     hdf5_type: H5T_STD_REF_OBJ<data> or H5T_INTEGER or H5T_FLOAT
-    short_description: References to arrays containing scalar raw data or data resulting from analysis of signals.
-    description: references to arrays containing the different values stored in the
-      dataset
-    dimensions: '[N_CS<m>] |[N_CS<m>,N_Gate<m>]'
-  DATATYPE:
-    full_name: ONDE_DATASET_UT_CSCAN:DATATYPE
-    required: true
-    storage: dataset
-    hdf5_type: H5T_STRING
-    short_description: A string defining the nature of the stored data, such as a custom property or a standardized name.
+    short_description: Reference to an array containing the Cscan data or array containing the CScan data.
     description: |-
-      string defining the stored data - the name can be either custom
-      (MY_MATERIAL_PROPERTY for instance) or a standardized name: THICKNESS,
-      TIME_OF_FLIGHT, DEPTH, AMAX
-    dimensions: '[N_CS<m>]'
+      The field contains either an array containing the CScan data (3D hdf5 dataset) or a reference to this array (hdf5 reference stored as an attribute).
+      Dimensions of this array are [N_U<m>, N_V<m>, N_A<m>], N_A<m> being the number of scans at each point. 
+      In the case of monoelement scans, the third dimension is therefore of size 1.
+    dimensions: '1 or [N_U<m>,N_V<m>,N_A<m>]'
   UNDERLYING_DATA:
     full_name: ONDE_DATASET_UT_CSCAN:UNDERLYING_DATA
     required: false
@@ -112,11 +79,12 @@ fields:
     short_description: A reference to a grid-type trajectory block used to position the C-scan data.
     description: ''
     dimensions: '1'
-  GATES:
-    full_name: ONDE_DATASET_UT_CSCAN:GATES
+  EXTRACTION:
+    full_name: ONDE_DATASET_UT_CSCAN:ONDE_UT_EXTRACTION
     required: false
-    storage: dataset
-    hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_GATE>
-    short_description: References to separate gate groups that define the time windows and thresholds used for data acquisition.
-    description: ''
-    dimensions: '[N_Gate<m>]'
+    storage: attribute
+    hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_EXTRACTION>
+    description: |- 
+      The referenced object describes the extraction process that was used 
+      to obtain the Cscan data from the underlying data.
+    dimensions: '1'

--- a/class_definitions/onde_dataset_ut_tscan.yaml
+++ b/class_definitions/onde_dataset_ut_tscan.yaml
@@ -54,6 +54,7 @@ description: |-
 fields:
   DATA:
     full_name: ONDE_DATASET:DATA
+    short_description: Contains the reconstructed T-scan data values.
     required: true
     storage: A or D
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_ASCAN_DATASET> or H5T_INTEGER
@@ -61,6 +62,7 @@ fields:
     dimensions: 1 or [N_U<m>,N_V<m>,N_ROW<m>,N_COL<m>] or [N_U<m>,N_V<m>,NROW<m>,NCOL<m>,N_PLANE<m>]
   ZONE_FRAME:
     full_name: ONDE_DATASET_UT_TSCAN:ZONE_FRAME
+    short_description: Defines the coordinate frame associated with the center of the image zone.
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
@@ -68,6 +70,7 @@ fields:
     dimensions: '[7]'
   ZONE_DIMENSION:
     full_name: ONDE_DATASET_UT_TSCAN:ZONE_DIMENSION
+    short_description: Specifies the physical dimensions of the reconstruction zone.
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
@@ -75,6 +78,7 @@ fields:
     dimensions: '[3]'
   ZONE_SIZE:
     full_name: ONDE_DATASET_UT_TSCAN:ZONE_SIZE
+    short_description: Defines the number of pixels along each axis of the reconstruction zone.
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
@@ -82,6 +86,7 @@ fields:
     dimensions: '[3]'
   RECONSTRUCTION_MODE:
     full_name: ONDE_DATASET_UT_TSCAN:RECONSTRUCTION_MODE
+    short_description: Specifies the mode or algorithm used for the reconstruction.
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
@@ -89,6 +94,7 @@ fields:
     dimensions: '1'
   REFERENCE_PROBE_INDEX:
     full_name: ONDE_DATASET_UT_TSCAN:REFERENCE_PROBE_INDEX
+    short_description: Indicates the index of the reference probe used for trajectory alignment.
     required: false
     storage: attribute
     hdf5_type: H5T_INTEGER
@@ -98,6 +104,7 @@ fields:
     dimensions: '1'
   SOURCE_ASCAN_DATASET:
     full_name: ONDE_DATASET_UT_TSCAN:SOURCE_ASCAN_DATASET
+    short_description: Points to the elementary channel A-scans dataset used for this reconstruction.
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_ASCAN_DATASET>

--- a/class_definitions/onde_dimension.yaml
+++ b/class_definitions/onde_dimension.yaml
@@ -4,6 +4,7 @@ description: ''
 fields:
   COORDINATE:
     full_name: ONDE_DIMENSION:COORDINATE
+    short_description: 'Name of the stored data or indexed coordinates.'
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
@@ -18,6 +19,7 @@ fields:
     dimensions: '1'
   UNITS:
     full_name: ONDE_DIMENSION:UNITS
+    short_description: 'Units for the stored data or indexed coordinates, preferably spelled-out MKS base units.'
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
@@ -33,6 +35,7 @@ fields:
     dimensions: '1'
   OFFSET:
     full_name: ONDE_DIMENSION:OFFSET
+    short_description: 'Offset value to be added to the scaled stored data or zero-based indices.'
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
@@ -44,6 +47,7 @@ fields:
     dimensions: '1'
   SCALE:
     full_name: ONDE_DIMENSION:SCALE
+    short_description: 'Scaling factor applied to the stored data or integer indices.'
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT

--- a/class_definitions/onde_dual_wedge.yaml
+++ b/class_definitions/onde_dual_wedge.yaml
@@ -8,6 +8,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: Distance between the probes in a dual probe setup.
     description: For dual probes, inter-probes distance (L6) (See Figure 15)
     dimensions: '1'
   ROOF_ANGLE:
@@ -15,6 +16,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: The roof angle for a dual probe wedge.
     description: |-
       For dual probes and only for dual probes defines the roof angle (See
       Figure 15)
@@ -24,5 +26,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: The squint angle of the dual probe wedge.
     description: For dual probes, squint angle (A2) (See Figure 15)
     dimensions: '1'

--- a/class_definitions/onde_geometric_setup.yaml
+++ b/class_definitions/onde_geometric_setup.yaml
@@ -20,6 +20,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_COMPONENT>
+    short_description: Reference to the inspected component.
     description: |-
       Reference to the inspected component. If missing, semi-infinite half plane
       is assumed, with interface at z=0 and material for z>0
@@ -29,6 +30,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_PROBE>
+    short_description: List of all probes used in the acquisition of the dataset.
     description: List all probes used in the acquisition of the dataset
     dimensions: '[N_Prob<M>]'
   ACQUISITION_TRAJECTORY:
@@ -36,6 +38,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_ACQUISITION_TRAJECTORY>
+    short_description: References to the block describing the trajectory.
     description: |-
       References to the block describing the trajectory, references have the
       same order as PROBE_LIST
@@ -45,6 +48,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: Offset and direction of the probe with respect to the trajectory frame.
     description: |-
       Offset and direction of the probe w.r.t the trajectory frame- identity is
       assumed if not provided

--- a/class_definitions/onde_geometric_setup.yaml
+++ b/class_definitions/onde_geometric_setup.yaml
@@ -18,7 +18,7 @@ fields:
   COMPONENT:
     full_name: ONDE_GEOMETRIC_SETUP:COMPONENT
     required: false
-    storage: dataset
+    storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_COMPONENT>
     description: |-
       Reference to the inspected component. If missing, semi-infinite half plane

--- a/class_definitions/onde_immersion.yaml
+++ b/class_definitions/onde_immersion.yaml
@@ -8,5 +8,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The designated path length through the water couplant during immersion."
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_linear_ut_probe.yaml
+++ b/class_definitions/onde_linear_ut_probe.yaml
@@ -9,6 +9,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_INTEGER
     description: ''
+    short_description: 'The total number of individual ultrasonic elements in this linear array probe.'
     dimensions: '1'
   ELEMENT_DIM_MAJOR:
     full_name: ONDE_LINEAR_UT_PROBE:ELEMENT_DIM_MAJOR
@@ -16,6 +17,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The dimension of a single element along the primary axis of the linear array.'
     dimensions: '1'
   ELEMENT_DIM_MINOR:
     full_name: ONDE_LINEAR_UT_PROBE:ELEMENT_DIM_MINOR
@@ -23,6 +25,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The dimension of a single element along the secondary axis (transverse to the array).'
     dimensions: '1'
   ELEMENT_PITCH_DIM_MAJOR:
     full_name: ONDE_LINEAR_UT_PROBE:ELEMENT_PITCH_DIM_MAJOR
@@ -30,6 +33,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The center-to-center spacing between adjacent elements along the primary axis of the linear array.'
     dimensions: '1'
   ELEMENT_NUMBERING:
     full_name: ONDE_LINEAR_UT_PROBE:ELEMENT_NUMBERING
@@ -40,4 +44,5 @@ fields:
       Defines the element numbering relating the numbering implicitly defined by
       the probe description and the order defined in the element tables
       (ELEMENT_POSITION, ELEMENT_GEOMETRY, etc)
+    short_description: 'Mapping between the probe''s physical element order and the indices used in the data tables.'
     dimensions: '[N_Elem<p>]'

--- a/class_definitions/onde_matrix_ut_probe.yaml
+++ b/class_definitions/onde_matrix_ut_probe.yaml
@@ -8,6 +8,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: 'Total number of elements in the matrix ultrasonic probe.'
     description: ''
     dimensions: '1'
   NUMBER_OF_ELEMENTS_DIM_MINOR:
@@ -15,6 +16,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: 'The number of elements along the minor dimension of the matrix probe.'
     description: ''
     dimensions: '1'
   ELEMENT_DIM_MAJOR:
@@ -22,6 +24,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Size of a single element along the major dimension.'
     description: ''
     dimensions: '1'
   ELEMENT_DIM_MINOR:
@@ -29,6 +32,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Size of a single element along the minor dimension.'
     description: ''
     dimensions: '1'
   ELEMENT_PITCH_DIM_MAJOR:
@@ -36,6 +40,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The pitch (center-to-center distance) between elements along the major dimension.'
     description: ''
     dimensions: '1'
   ELEMENT_PITCH_DIM_MINOR:
@@ -43,6 +48,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The pitch (center-to-center distance) between elements along the minor dimension.'
     description: ''
     dimensions: '1'
   ELEMENT_NUMBERING:
@@ -50,6 +56,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_INTEGER
+    short_description: 'Defines the element numbering relating the implicitly defined numbering and the order in the element tables.'
     description: |-
       Defines the element numbering relating the numbering implicitly defined by
       the probe description and the order defined in the element tables

--- a/class_definitions/onde_phased_array_angle.yaml
+++ b/class_definitions/onde_phased_array_angle.yaml
@@ -12,6 +12,7 @@ description: |-
 fields:
   BSCAN_ANGLE:
     full_name: ONDE_PHASED_ARRAY_ANGLE:BSCAN_ANGLE
+    short_description: "The specified angle for the ultrasonic ray direction."
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT

--- a/class_definitions/onde_phased_array_compound.yaml
+++ b/class_definitions/onde_phased_array_compound.yaml
@@ -23,6 +23,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The initial angle of the scope for the compound scan."
     description: ''
     dimensions: '1'
   FINAL_ANGLE:
@@ -30,6 +31,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The final angle of the scope for the compound scan."
     description: ''
     dimensions: '1'
   NUMBER_OF_ANGLES:
@@ -37,6 +39,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: "The total number of angles defined within the compound scan scope."
     description: ''
     dimensions: '1'
   NUMBER_OF_ELEMENTS:
@@ -44,5 +47,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: "The number of elements involved in the electronic scanning process."
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_phased_array_escan.yaml
+++ b/class_definitions/onde_phased_array_escan.yaml
@@ -19,6 +19,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: 'The number of consecutive elements used to form a beam.'
     description: ''
     dimensions: '1'
   STEP:
@@ -26,6 +27,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: 'The number of elements by which the subset is shifted for each successive beam.'
     description: ''
     dimensions: '1'
   ANGLE:
@@ -33,5 +35,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The specific angle at which the beam is formed during the scan.'
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_phased_array_pwi.yaml
+++ b/class_definitions/onde_phased_array_pwi.yaml
@@ -8,6 +8,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The starting angle for the plane wave imaging (PWI) sweep.'
     description: ''
     dimensions: '1'
   FINISHING_ANGLE:
@@ -15,6 +16,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The finishing angle for the plane wave imaging (PWI) sweep.'
     description: ''
     dimensions: '1'
   NUMBER_OF_ANGLES:
@@ -22,5 +24,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: 'The total number of discrete angles used in the plane wave imaging (PWI) sweep.'
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_phased_array_setup.yaml
+++ b/class_definitions/onde_phased_array_setup.yaml
@@ -27,6 +27,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_PROBE>
+    short_description: "Reference to the emitting phased array probe used in this setup."
     description: ''
     dimensions: '1'
   RECEIVING_PROBE:
@@ -34,6 +35,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_PROBE>
+    short_description: "Reference to the receiving phased array probe used in this setup."
     description: ''
     dimensions: '1'
   SEQUENCE_ANGLE_MODE:
@@ -41,5 +43,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: "Specifies the wave propagation mode used for the setup sequence, such as longitudinal (L) or transverse (T)."
     description: ''
     allowed_values: '"L"|"T"'

--- a/class_definitions/onde_phased_array_sscan.yaml
+++ b/class_definitions/onde_phased_array_sscan.yaml
@@ -18,6 +18,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The first emission or reception angle in the linearly varying set for the SScan."
     description: ''
     dimensions: '1'
   FINISHING_ANGLE:
@@ -25,6 +26,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The final emission or reception angle in the linearly varying set for the SScan."
     description: ''
     dimensions: '1'
   NUMBER_OF_ANGLES:
@@ -32,5 +34,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: "The total number of shots or linearly varying angles defining the set for the SScan."
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_plane.yaml
+++ b/class_definitions/onde_plane.yaml
@@ -17,5 +17,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The dimensions of the planar specimen, represented as a triplet of length, width, and thickness."
     description: ''
     dimensions: '[3]'

--- a/class_definitions/onde_setup.yaml
+++ b/class_definitions/onde_setup.yaml
@@ -9,6 +9,7 @@ fields:
     full_name: ONDE_SETUP:GEOMETRIC_SETUP
     required: true
     storage: attribute
+    short_description: "Reference to the geometric setup configuration."
     hdf5_type: H5T_STD_REF_OBJ<ONDE_GEOMETRIC_SETUP>
     description: ''
     dimensions: '[1]'

--- a/class_definitions/onde_setup_ut.yaml
+++ b/class_definitions/onde_setup_ut.yaml
@@ -8,5 +8,6 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_ULTRASONIC_SETUP>
+    short_description: Defines the ultrasonic setup configuration for the sequence.
     description: Mandatory for Ascan sequences
     dimensions: '[1]'

--- a/class_definitions/onde_spatial_trajectory.yaml
+++ b/class_definitions/onde_spatial_trajectory.yaml
@@ -27,6 +27,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: A 3D array detailing the positions and orientations of the acquisition frame across the trajectory. Each point is defined by 3D coordinates and a quaternion.
     description: |-
       List of positions and quaternions giving the positions and orientations of
       the trajectory frame at the different positions

--- a/class_definitions/onde_time_trajectory.yaml
+++ b/class_definitions/onde_time_trajectory.yaml
@@ -12,5 +12,6 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "Defines the acquisition rate for time encoded trajectories."
     description: For time encoded trajectories, defines the acquisition rate
     dimensions: '1'

--- a/class_definitions/onde_ultrasonic_setup.yaml
+++ b/class_definitions/onde_ultrasonic_setup.yaml
@@ -84,6 +84,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Label for the ultrasonic setup.'
     description: ''
     dimensions: '1'
   RECTIFICATION:
@@ -91,6 +92,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Defines the rectification mode applied to the ultrasonic data.'
     description: |-
       Defines if the data are FULL_WAVE or RECTIFIED_POSITIVE,
       RECTIFIED_NEGATIVE, RECTIFIED_FULL
@@ -100,6 +102,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Specifies the type of filtering applied to the signals.'
     description: |-
       Defines the type of filtering applied to the signals: NO_FILTER,
       LOW_PASS, HIGH_PASS, BAND_PASS, OTHER
@@ -109,6 +112,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Provides the parameters for the analogue filter.'
     description: |-
       Optional datafield providing analogue filter parameters - see notes for
       detailed explanation
@@ -118,6 +122,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'A textual description of the filtering applied.'
     description: Description of the filtering applied
     dimensions: '1'
   ASCAN_SAMPLE_RATE:
@@ -125,6 +130,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The sampling frequency of the A-scan data points.'
     description: |-
       This indicates the sampling frequency of A-scan data points. It is assumed
       that a uniform sampling rate is used throughout A-scan data collection.
@@ -134,6 +140,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The starting time for data acquisition.'
     description: |-
       This indicates the starting time for data acquisition. If dimension is 1,
       the same start time is used for all A-Scans, else a different start time
@@ -144,6 +151,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'Digitization of the emission signal.'
     description: |-
       Digitization of the emission signal (can be used to store arbitrary
       signals). If missing impulse emission at time 0.0 is assumed. 2D Array
@@ -154,6 +162,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The total gain applied for each A-scan during reception.'
     description: |-
       This indicates the total gain for each A-scan during
       reception. Multiplying factor that was applied at acquisition.
@@ -163,6 +172,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The Pulse Repetition Frequency (PRF) for the signals.'
     description: Pulse Repetition Frequency
     dimensions: '[N_Ascan<m>] or [2]'
   TCG_CURVE:
@@ -170,6 +180,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The Time Corrected Gain (TCG) curve applied to the received signals.'
     description: |-
       TCG curve applied to the received signals. The amplitude correction is
       given for each time sample as a multiplying factor.
@@ -179,6 +190,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_PHASED_ARRAY_SETUP>
+    short_description: 'Reference to the associated phased array setup.'
     description: ''
     dimensions: '1'
   TRANSMIT_LAW:
@@ -186,6 +198,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_LAW>
+    short_description: 'HDF5 reference to the transmit focal law group.'
     description: |-
       Each A-scan in a dataframe must be associated with both a transmit and a
       receive focal law through the datafields. These contain HDF5 references to
@@ -198,6 +211,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_LAW>
+    short_description: 'HDF5 reference to the receive focal law group.'
     description: |-
       Each A-scan in a dataframe must be associated with both a transmit and a
       receive focal law through the datafields. These contain HDF5 references to

--- a/class_definitions/onde_ut.yaml
+++ b/class_definitions/onde_ut.yaml
@@ -49,6 +49,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Identifies the file type as an ONDE UT file.'
     description: |-
       For detailed information, see
       https://github.com/COFREND/ONDE-format/blob/main/UT_specification/UT_file_format.md
@@ -59,6 +60,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Specifies the version of the ONDE UT specification that this file conforms to.'
     description: ''
     dimensions: '1'
     allowed_values: '"0.9.1"'

--- a/class_definitions/onde_ut_coupling.yaml
+++ b/class_definitions/onde_ut_coupling.yaml
@@ -8,6 +8,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: "The velocity of the acoustic waves propagating within the coupling medium."
     dimensions: '[2]'
   MEDIUM_DENSITY:
     full_name: ONDE_UT_COUPLING:MEDIUM_DENSITY
@@ -15,6 +16,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: "The density of the coupling medium."
     dimensions: '1'
   INCIDENCE_ANGLE:
     full_name: ONDE_UT_COUPLING:INCIDENCE_ANGLE
@@ -22,4 +24,5 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: "The angle of incidence of the acoustic wave as it travels into the coupling medium."
     dimensions: '1'

--- a/class_definitions/onde_ut_elements.yaml
+++ b/class_definitions/onde_ut_elements.yaml
@@ -59,6 +59,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'Defines the position and orientation of each probe element.'
     description: Array defining the location of the elements of the probe
     dimensions: '[N_Elem<p>,7]'
   SHAPE:
@@ -66,6 +67,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_INTEGER
+    short_description: 'Specifies the geometric shape of each probe element.'
     description: 'The shape of each element will be defined as one of the following:
       rectangle (ELE_GEOM_REC), part of a ring (ELE_GEOM_RING_PART), part of an elliptical
       ring (ELE_GEOM_ELLIPSE_PART),'
@@ -75,6 +77,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'Provides six parameters that specify the dimensions of each element.'
     description: ''
     dimensions: '[N_Elem<p>,6]'
   RADIUS_OF_CURVATURE:
@@ -82,6 +85,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The radius of curvature for elements that are not flat.'
     description: If absent, flat elements are assumed
     dimensions: '[N_Elem<p>]'
   AXIS_OF_CURVATURE:
@@ -89,6 +93,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The vector defining the axis of curvature for non-flat elements.'
     description: If absent, flat elements are assumed
     dimensions: '[N_Elem<p>,3]'
   DEAD_ELEMENT:
@@ -96,6 +101,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_INTEGER
+    short_description: 'Logical flags indicating non-functioning elements in a probe.'
     description: |-
       Datafield of logical values (0 = false, 1 = true) used to flag
       non-functioning elements in an array probe (if not present, assumption

--- a/class_definitions/onde_ut_extraction.yaml
+++ b/class_definitions/onde_ut_extraction.yaml
@@ -1,0 +1,56 @@
+onde_class: ONDE_UT_EXTRACTION
+inherits: [ONDE_COMPUTATION]
+description: |-
+   
+   ### UT Extractions
+
+    The UT extractions are the entry points for the description of data that is
+    extracted from raw Ascan or TScan data, resulting in a CScan. 
+    
+    The extraction can be either a scalar value or an enumeration.
+    The extraction relates to list of *ONDE_UT_GATE*, called
+    GATE_LIST which can be of size 1 or 2 :
+    
+    - If the list is of size 1,  the gate defines the time window for 
+    the extraction.
+
+    - If the list is of size 2,  the extracted value is the difference
+     between the two extractions, each defined by a gate. 
+
+    The nature of the extraction is defined by the EXTRACTION_TYPE field, 
+    which can be either *TIME_OF_FLIGHT*, *AMPLITUDE*, *DEPTH* or *ALARM*.
+
+    - In the case of *DEPTH*, a *VELOCITY* field must be defined, which 
+    is the velocity of the wave in the material. 
+      The depth is then computed as *'DEPTH = VELOCITY * TIME_OF_FLIGHT / 2'*. 
+
+    - In the case of *ALARM*, the expected values in the dataset are 0 and 1. The 
+    alarm condition is the overshoot of the threshold defined in the gate. 
+    *ALARM* datatype is not compliant with two gates in the GATE_LIST field.
+
+
+
+fields:
+  START:
+    full_name: ONDE_UT_EXTRACTION:GATE_LIST
+    required: true
+    storage: attribute
+    hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_GATE>
+    description: |-
+      References to the gates that are used for the extraction. The list can be of size 1 or 2.
+    dimensions: '[1] or [2]'
+  WIDTH:
+    full_name: ONDE_UT_EXTRACTION:DATATYPE
+    required: true
+    storage: attribute
+    hdf5_type: H5T_STRING
+    description: |-
+      Defines the type of extraction. The allowed values are *TIME_OF_FLIGHT*, *AMPLITUDE*, *DEPTH* or *ALARM*.
+    dimensions: '"TIME_OF_FLIGHT"|"AMPLITUDE"|"DEPTH"|"ALARM"'
+  VELOCITY:
+    full_name: ONDE_UT_EXTRACTION:VELOCITY
+    required: false
+    storage: attribute
+    hdf5_type: H5T_FLOAT
+    description: Defines the velocity of the wave in the material, used to translate the time of flight into depth.
+    dimensions: '1'

--- a/class_definitions/onde_ut_gate.yaml
+++ b/class_definitions/onde_ut_gate.yaml
@@ -7,6 +7,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "Defines the start time for the ultrasonic gate."
     description: |-
       For scalar data relying on Ascan data, defines the start time for the
       gate. Mandatory for data related to Ascans.
@@ -16,6 +17,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "Defines the width of the ultrasonic gate."
     description: |-
       For Cscans scalar data relying on Ascan data, defines the width of the
       gate. Mandatory for data related to Ascans
@@ -25,6 +27,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "Defines the threshold of the gate for data storage."
     description: Defines the threshold of the gate for data to be stored
     dimensions: '1'
   DETECTION:
@@ -32,6 +35,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: "Specifies the peak or flank detection mode for the gate."
     description: ''
     dimensions: '1'
     allowed_values: '"FIRST_PEAK"|"LAST_PEAK"|"MAX_PEAK"|"FIRST_FLANK"|"LAST_FLANK"|"MAX_FLANK"'
@@ -40,6 +44,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: "Specifies the polarity used for gate detection."
     description: ''
     dimensions: '1'
     allowed_values: '"ABSOLUTE"|"POSITIVE"|"NEGATIVE"'

--- a/class_definitions/onde_ut_gate.yaml
+++ b/class_definitions/onde_ut_gate.yaml
@@ -1,6 +1,41 @@
 onde_class: ONDE_UT_GATE
 inherits: []
-description: ''
+description: |-
+   
+   ### UT Gates
+
+    The gates are referenced in the ONDE_UT_EXTRACTION group.  
+    The gate model accomodates the description of static gates and gates 
+    resulting from synchronization. The gates
+    used for the acquisition are
+    defined through the following parameters:
+
+    - GATE_START and GATE_WIDTH define the time
+    window
+    - GATE_THRESHOLD defines the threshold that was used to trigger the
+    storage of the data 
+    - GATE_DETECTION defines the type of triggering event
+    that was used to define the gate
+    - GATE_POLARITY defines the mode that was
+    used for the detection (absolute, positive or negative).
+    - GATE_SYNCHRONIZATION_SOURCE defines the source of the synchronization for the gate. 
+    It is a reference to another gate. If absent, the gate is defined as a static gate. 
+    
+    The following
+    figure defines the modes that can be used for detection. The numbers on the
+    figure correspond to the different triggering events. The correspondence
+    between these figures and the values allowed for GATE_DETECTION is the
+    following:
+
+    1. FIRST_FLANK
+    2. FIRST_PEAK
+    3. MAX_FLANK
+    4. MAX_PEAK
+    5. LAST_PEAK
+    6. LAST_FLANK
+
+    ![Detection modes for UT gates](../images/media/gate_detection.png)
+
 fields:
   START:
     full_name: ONDE_UT_GATE:START
@@ -48,3 +83,12 @@ fields:
     description: ''
     dimensions: '1'
     allowed_values: '"ABSOLUTE"|"POSITIVE"|"NEGATIVE"'
+  SYNCHRONIZATION_SOURCE:
+    full_name: ONDE_UT_GATE:SYNCHRONIZATION_SOURCE
+    required: false
+    storage: attribute
+    hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_GATE>
+    description: |-
+      Reference to the gate that is used as a synchronization source for this gate.
+      If absent, the gate is defined as a static gate.
+    dimensions: '1'

--- a/class_definitions/onde_ut_gate.yaml
+++ b/class_definitions/onde_ut_gate.yaml
@@ -1,6 +1,41 @@
 onde_class: ONDE_UT_GATE
 inherits: []
-description: ''
+description: |-
+   
+   ### UT Gates
+
+    The gates are referenced in the ONDE_UT_EXTRACTION group.  
+    The gate model accomodates the description of static gates and gates 
+    resulting from synchronization. The gates
+    used for the acquisition are
+    defined through the following parameters:
+
+    - GATE_START and GATE_WIDTH define the time
+    window
+    - GATE_THRESHOLD defines the threshold that was used to trigger the
+    storage of the data 
+    - GATE_DETECTION defines the type of triggering event
+    that was used to define the gate
+    - GATE_POLARITY defines the mode that was
+    used for the detection (absolute, positive or negative).
+    - GATE_SYNCHRONIZATION_SOURCE defines the source of the synchronization for the gate. 
+    It is a reference to another gate. If absent, the gate is defined as a static gate. 
+    
+    The following
+    figure defines the modes that can be used for detection. The numbers on the
+    figure correspond to the different triggering events. The correspondence
+    between these figures and the values allowed for GATE_DETECTION is the
+    following:
+
+    1. FIRST_FLANK
+    2. FIRST_PEAK
+    3. MAX_FLANK
+    4. MAX_PEAK
+    5. LAST_PEAK
+    6. LAST_FLANK
+
+    ![Detection modes for UT gates](../images/media/gate_detection.png)
+
 fields:
   START:
     full_name: ONDE_UT_GATE:START
@@ -43,3 +78,12 @@ fields:
     description: ''
     dimensions: '1'
     allowed_values: '"ABSOLUTE"|"POSITIVE"|"NEGATIVE"'
+  SYNCHRONIZATION_SOURCE:
+    full_name: ONDE_UT_GATE:SYNCHRONIZATION_SOURCE
+    required: false
+    storage: attribute
+    hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_GATE>
+    description: |-
+      Reference to the gate that is used as a synchronization source for this gate.
+      If absent, the gate is defined as a static gate.
+    dimensions: '1'

--- a/class_definitions/onde_ut_law.yaml
+++ b/class_definitions/onde_ut_law.yaml
@@ -17,6 +17,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_PROBE>
+    short_description: 'A reference to the ultrasonic probe used in this focal law.'
     description: ''
     dimensions: '[N_C<k>]'
   ELEMENT:
@@ -24,6 +25,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_INTEGER
+    short_description: 'The index or identifier of the probe element used in this focal law.'
     description: ''
     dimensions: '[N_C<k>]'
   DELAY:
@@ -31,6 +33,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The relative delay applied to each probe element combination.'
     description: |-
       Specifies the relative delay (in ultrasonic time) between the different
       Probe Element Combinations in the focal law. The default value is zero
@@ -41,6 +44,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The weighting factor applied to each probe element combination.'
     description: |-
       Specifies the weighting between the different Probe Element Combinations
       in the focal law. The default is one for all Probe Element Combinations.
@@ -50,6 +54,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The ultrasonic ray along which the data is to be represented.'
     description: |-
       Represents the ultrasonic ray along which the data is to be represented in
       a true visualisation. It contains at least two points in the Probe

--- a/class_definitions/onde_ut_probe.yaml
+++ b/class_definitions/onde_ut_probe.yaml
@@ -37,6 +37,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Type tags for the UT probe.'
     description: ''
     dimensions: '[1]'
     allowed_values: '["ONDE_UT_ELEMENTS"]'
@@ -45,6 +46,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Human-readable label for the probe.'
     description: ''
     dimensions: '1'
   MANUFACTURER:
@@ -52,6 +54,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'The manufacturer of the probe.'
     description: ''
     dimensions: '1'
   SERIAL_NUMBER:
@@ -59,6 +62,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'The serial number of the probe.'
     description: ''
     dimensions: '1'
   FREQUENCY:
@@ -66,6 +70,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The operating frequency of the probe.'
     description: ''
     dimensions: '1'
   BANDWIDTH:
@@ -73,6 +78,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The frequency bandwidth of the probe.'
     description: ''
     dimensions: '1'
   INDEX_POINT_FRAME:
@@ -80,6 +86,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'Frame of reference for the index point of the probe.'
     description: If absent, identity is assumed
     dimensions: '[7]'
   FOCUSING_SURFACE:
@@ -87,6 +94,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Shape of the surface on which the elements are arranged.'
     description: |-
       Defines the shape of the surface on which the elements are arranged —if
       absent, FLAT is assumed
@@ -96,6 +104,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Geometric parameters defining the focusing surface.'
     description: |-
       Multi values: value in mm
 
@@ -113,5 +122,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_COUPLING>
+    short_description: 'Reference to the coupling system used with the probe.'
     description: Reference to the coupling system (wedge, immersion, direct)
     dimensions: '1'

--- a/class_definitions/onde_wedge.yaml
+++ b/class_definitions/onde_wedge.yaml
@@ -74,6 +74,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Label or identifier for the wedge.'
     description: ''
     dimensions: '1'
   MANUFACTURER:
@@ -81,6 +82,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Manufacturer of the wedge.'
     description: ''
     dimensions: '1'
   SERIAL_NUMBER:
@@ -88,6 +90,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Serial number of the wedge.'
     description: ''
     dimensions: '1'
   CONTACT_SURFACE:
@@ -95,6 +98,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Type of the wedge contact surface.'
     description: |-
       Type of the wedge contact surface - PLANAR, SPHERICAL, CYLINDRICAL_MAJOR,
       CYLINDRICAL_MINOR - If missing PLANAR assumed
@@ -104,6 +108,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Radius of curvature for the wedge contact surface.'
     description: |-
       Wedge curvature radius (0 assumed if missing)
 
@@ -117,6 +122,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Dimensions defining the equivalent contact area of the wedge.'
     description: Equivalent to L1, L2 and L3 (See Figure 15)
     dimensions: '[3]'
   HEIGHT:
@@ -124,6 +130,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Distance of the ultrasonic beam between the probe center and the index point.'
     description: |-
       For a wedge, distance of the ultrasonic beam between the probe center and
       the index point (See Figure 15)
@@ -133,6 +140,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Skew angle of the wedge.'
     description: wedge /skew angle (B) (See Figure 15)
     dimensions: '1'
   DISORIENTATION_ANGLE:
@@ -140,5 +148,6 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Disorientation angle of the wedge.'
     description: wedge /disorientation angle (D) (See Figure 15)
     dimensions: '1'

--- a/class_definitions/onde_weld.yaml
+++ b/class_definitions/onde_weld.yaml
@@ -9,6 +9,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_STRING
     description: ''
+    short_description: 'Specifies the type of extrusion for the weld geometry.'
     dimensions: '1'
     allowed_values: '"PLANE"|"CYLINDER"'
   EXTRUSION_DIMENSION:
@@ -17,6 +18,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The physical dimension used for the weld extrusion process.'
     dimensions: '1'
   WELD_TYPE:
     full_name: ONDE_WELD:WELD_TYPE
@@ -24,6 +26,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_STRING
     description: ''
+    short_description: 'Specifies the shape type of the weld groove (e.g., V or U).'
     dimensions: '1'
     allowed_values: '"V"|"U"'
   WELD_SYMMETRY:
@@ -32,6 +35,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_STRING
     description: ''
+    short_description: 'Describes the symmetry configuration of the weld geometry.'
     dimensions: '1'
     allowed_values: '"SYMMETRIC"|"STRAIGHT_LEFT"|"STRAIGHT_RIGHT"'
   WELD_UPPER_CAP_WIDTH:
@@ -40,6 +44,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The width of the upper cap of the weld.'
     dimensions: '1'
   WELD_UPPER_CAP_HEIGHT:
     full_name: ONDE_WELD:WELD_UPPER_CAP_HEIGHT
@@ -47,6 +52,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the upper cap of the weld.'
     dimensions: '1'
   WELD_FILL_ANGLE:
     full_name: ONDE_WELD:WELD_FILL_ANGLE
@@ -54,6 +60,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The angle of the fill pass for the weld.'
     dimensions: '1'
   WELD_FILL_HEIGHT:
     full_name: ONDE_WELD:WELD_FILL_HEIGHT
@@ -61,6 +68,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the fill pass for the weld.'
     dimensions: '1'
   WELD_HOT_PASS_ANGLE:
     full_name: ONDE_WELD:WELD_HOT_PASS_ANGLE
@@ -68,6 +76,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The angle of the hot pass layer in the weld.'
     dimensions: '1'
   WELD_HOT_PASS_HEIGHT:
     full_name: ONDE_WELD:WELD_HOT_PASS_HEIGHT
@@ -75,6 +84,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the hot pass layer in the weld.'
     dimensions: '1'
   WELD_LAND_OFFSET:
     full_name: ONDE_WELD:WELD_LAND_OFFSET
@@ -82,6 +92,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The offset measurement for the root land of the weld.'
     dimensions: '1'
   WELD_LAND_HEIGHT:
     full_name: ONDE_WELD:WELD_LAND_HEIGHT
@@ -89,6 +100,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the root land of the weld.'
     dimensions: '1'
   WELD_ROOT_ANGLE:
     full_name: ONDE_WELD:WELD_ROOT_ANGLE
@@ -96,6 +108,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The angle of the root pass for the weld.'
     dimensions: '1'
   WELD_ROOT_HEIGHT:
     full_name: ONDE_WELD:WELD_ROOT_HEIGHT
@@ -103,6 +116,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the root pass for the weld.'
     dimensions: '1'
   WELD_LOWER_CAP_HEIGHT:
     full_name: ONDE_WELD:WELD_LOWER_CAP_HEIGHT
@@ -110,6 +124,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the lower cap of the weld.'
     dimensions: '1'
   WELD_LOWER_CAP_WIDTH:
     full_name: ONDE_WELD:WELD_LOWER_CAP_WIDTH
@@ -117,6 +132,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The width of the lower cap of the weld.'
     dimensions: '1'
   WELD_HAZ_WIDTH:
     full_name: ONDE_WELD:WELD_HAZ_WIDTH
@@ -124,4 +140,5 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The width of the heat-affected zone (HAZ) of the weld.'
     dimensions: '1'

--- a/specification/data_model.md
+++ b/specification/data_model.md
@@ -4,7 +4,7 @@
 The ONDE Data Model is defined by classes, which group together named fields. When implemented in the ONDE file, these classes translate into HDF5 groups. This section of the documentation describes:
 
 - the principles used to define the classes (including subclasses and accessory classes) and the fields in the data model,
-- the transcription of this data model in the reference csv file (see [ONDE_fields.csv](ONDE_fields.csv)),
+- the transcription of this data model in the reference csv file (see [ONDE_fields.csv](ONDE_fields.csv)). This CSV file is provided for simplified use in automated tooling where the individual YAML files may become too cumbersome for quick import or validation purposes.
 - the way in which this data model translates into an HDF5 implementation in the ONDE file.
 
 

--- a/specification/data_model.md
+++ b/specification/data_model.md
@@ -4,7 +4,7 @@
 The ONDE Data Model is defined by classes, which group together named fields. When implemented in the ONDE file, these classes translate into HDF5 groups. This section of the documentation describes:
 
 - the principles used to define the classes (including subclasses and accessory classes) and the fields in the data model,
-- the transcription of this data model in the reference csv file (see https://github.com/COFREND/ONDE-format/blob/main/ONDE_fields/ONDE_fields.csv),
+- the transcription of this data model in the reference csv file (see [ONDE_fields.csv](ONDE_fields.csv)),
 - the way in which this data model translates into an HDF5 implementation in the ONDE file.
 
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -59,6 +59,8 @@
 - All quantities are defined with SI units. Units are therefore expressed in meters, kilograms,
   seconds. However, degrees are used instead of radians.
 
+- The formal Single Source of Truth for the data model is defined via YAML files, which are compiled to generate this documentation. A unified CSV export is also provided (see [ONDE_fields.csv](ONDE_fields.csv)). This CSV file is provided for simplified use in automated tooling where the individual YAML files may become too cumbersome for quick import or validation purposes.
+
 ## Tables legend
 
 In the following sections, the data structure is described by blocks presented in tables.

--- a/tools/generate_csv.py
+++ b/tools/generate_csv.py
@@ -57,7 +57,8 @@ def generate_csv():
             'required': True,
             'storage': 'attribute',
             'hdf5_type': 'H5T_STRING',
-            'description': '',
+            'short_description': 'Specifies the ONDE class and its inheritance hierarchy.',
+            'description': 'The `ONDE:TYPE` attribute dictates the semantic meaning of the HDF5 group. It contains a 1D array of strings that traces the class inheritance from the root class down to this specific class.',
             'dimensions': dim_str,
             'allowed_values': allowed_str
         }

--- a/tools/generate_csv.py
+++ b/tools/generate_csv.py
@@ -9,9 +9,8 @@ def parse_yaml(filepath):
     with open(filepath, 'r', encoding='utf-8') as f:
         return yaml.safe_load(f)
 
-def generate_csv():
+def generate_csv(output_csv='build/ONDE_fields.csv'):
     input_dir = 'class_definitions'
-    output_csv = 'build/ONDE_fields.csv'
     
     os.makedirs(os.path.dirname(output_csv), exist_ok=True)
     

--- a/tools/generate_csv.py
+++ b/tools/generate_csv.py
@@ -31,6 +31,7 @@ def generate_csv():
             
     # Inject TYPE fields dynamically based on inheritance for classes
     def get_inheritance_chain_dict(c_name, visited=None):
+        """returns inheritance list with base class last"""
         if visited is None: visited = set()
         if c_name in visited or not c_name: return []
         visited.add(c_name)
@@ -48,9 +49,10 @@ def generate_csv():
     for c_data in classes_data:
         cls_name = c_data.get('onde_class', '')
         
-        chain = get_inheritance_chain_dict(cls_name)
-        allowed_str = '["' + '", "'.join(chain) + '"]'
-        dim_str = f'[{len(chain)}]' if len(chain) > 1 else '1'
+        # Obtain inheritance list with base class first
+        chain_fwd = get_inheritance_chain_dict(cls_name)[::-1]
+        allowed_str = '["' + '", "'.join(chain_fwd) + '"]'
+        dim_str = f'[{len(chain_fwd)}]' if len(chain_fwd) > 1 else '1'
         
         type_field = {
             'full_name': 'ONDE:TYPE',

--- a/tools/generate_csv.py
+++ b/tools/generate_csv.py
@@ -31,7 +31,7 @@ def generate_csv():
             
     # Inject TYPE fields dynamically based on inheritance for classes
     def get_inheritance_chain_dict(c_name, visited=None):
-        """returns inheritance list with base class last"""
+        """returns inheritance list with base class first"""
         if visited is None: visited = set()
         if c_name in visited or not c_name: return []
         visited.add(c_name)
@@ -42,7 +42,7 @@ def generate_csv():
         inherits = c_data.get('inherits', [])
         chain = [c_name]
         for parent in inherits:
-            chain.extend(get_inheritance_chain_dict(parent, visited))
+            chain = get_inheritance_chain_dict(parent, visited) + chain # list concatenation
         
         return chain
 
@@ -50,9 +50,9 @@ def generate_csv():
         cls_name = c_data.get('onde_class', '')
         
         # Obtain inheritance list with base class first
-        chain_fwd = get_inheritance_chain_dict(cls_name)[::-1]
-        allowed_str = '["' + '", "'.join(chain_fwd) + '"]'
-        dim_str = f'[{len(chain_fwd)}]' if len(chain_fwd) > 1 else '1'
+        chain = get_inheritance_chain_dict(cls_name)
+        allowed_str = '["' + '", "'.join(chain) + '"]'
+        dim_str = f'[{len(chain)}]' if len(chain) > 1 else '1'
         
         type_field = {
             'full_name': 'ONDE:TYPE',

--- a/tools/generate_docs.py
+++ b/tools/generate_docs.py
@@ -356,7 +356,8 @@ details.field-details .field-content hr {
             required=True,
             storage="attribute",
             hdf5_type="H5T_STRING",
-            description="",
+            short_description="Specifies the ONDE class and its inheritance hierarchy.",
+            description="The `ONDE:TYPE` attribute dictates the semantic meaning of the HDF5 group. It contains a 1D array of strings that traces the class inheritance from the root class down to this specific class.",
             dimensions=dim_str,
             allowed_values=allowed_str
         )

--- a/tools/generate_docs.py
+++ b/tools/generate_docs.py
@@ -62,8 +62,28 @@ classDiagram
 <div class="field-list" markdown="1">
 {% for name, f in fields_meta %}
 {% set summary_content %}
-<div class="field-summary-top" markdown="span"><strong id="{{ cls.onde_class | lower }}-{{ name | lower | replace(' ', '-') }}"><code>{{ name }}</code></strong>{% if f.is_inherited %} <span class="inherited-badge" markdown="span">Inherited from [{{ f.source }}]({{ f.source | lower }}.md)</span>{% elif f.is_accessory %} <span class="accessory-badge" markdown="span">From accessory class [{{ f.source }}]({{ f.source | lower }}.md)</span>{% endif %}{% if f.short_desc %} &mdash; {{ f.short_desc }}{% endif %}</div>
-<div class="field-summary-bottom" markdown="span"><span markdown="span">**Type:** {{ f.html_type }}</span><span markdown="span">**Dimensions:** {% if f.dimensions %}`{{ f.dimensions }}`{% else %}-{% endif %}</span><span markdown="span">**Required:** {{ f.req_str }}</span><span markdown="span">**Storage:** {{ f.storage }}</span>{% if f.allowed %}<span markdown="span">**Allowed:** `{{ f.allowed }}`</span>{% endif %}{% if f.min_value %}<span markdown="span">**Min:** `{{ f.min_value }}`</span>{% endif %}{% if f.max_value %}<span markdown="span">**Max:** `{{ f.max_value }}`</span>{% endif %}</div>
+<div class="field-summary-header" markdown="span">
+  <strong class="field-name" id="{{ cls.onde_class | lower }}-{{ name | lower | replace(' ', '-') }}"><code>{{ name }}</code></strong>
+  <span class="field-type" markdown="span">{{ f.html_type }}</span>
+  {% if f.req_str == 'Yes' %}<span class="req-badge req-yes">Required</span>{% else %}<span class="req-badge req-no">Optional</span>{% endif %}
+  {% if f.is_inherited %}
+    <span class="inherited-badge" markdown="span">Inherited from [{{ f.source }}]({{ f.source | lower }}.md)</span>
+  {% elif f.is_accessory %}
+    <span class="accessory-badge" markdown="span">From accessory class [{{ f.source }}]({{ f.source | lower }}.md)</span>
+  {% endif %}
+</div>
+{% if f.short_desc %}
+<div class="field-summary-desc" markdown="span">{{ f.short_desc }}</div>
+{% endif %}
+<table class="field-meta-table">
+  <tbody>
+    <tr><td>Storage:</td><td><span markdown="span">{{ f.storage }}</span></td></tr>
+    {% if f.dimensions %}<tr><td>Dimensions:</td><td><code>{{ f.dimensions | e }}</code></td></tr>{% endif %}
+    {% if f.allowed %}<tr><td>Allowed:</td><td><code>{{ f.allowed | e }}</code></td></tr>{% endif %}
+    {% if f.min_value %}<tr><td>Min:</td><td><code>{{ f.min_value | e }}</code></td></tr>{% endif %}
+    {% if f.max_value %}<tr><td>Max:</td><td><code>{{ f.max_value | e }}</code></td></tr>{% endif %}
+  </tbody>
+</table>
 {% endset %}
 
 {% if f.description %}
@@ -97,8 +117,23 @@ MODALITY_TEMPLATE = """\
 <div class="field-list" markdown="1">
 {% for name, f in fields_meta %}
 {% set summary_content %}
-<div class="field-summary-top" markdown="span"><strong id="{{ mod.modality | lower }}-{{ name | lower | replace(' ', '-') }}"><code>{{ name }}</code></strong>{% if f.short_desc %} &mdash; {{ f.short_desc }}{% endif %}</div>
-<div class="field-summary-bottom" markdown="span"><span markdown="span">**Type:** {{ f.html_type }}</span><span markdown="span">**Dimensions:** {% if f.dimensions %}`{{ f.dimensions }}`{% else %}-{% endif %}</span><span markdown="span">**Required:** {{ f.req_str }}</span><span markdown="span">**Storage:** {{ f.storage }}</span>{% if f.allowed %}<span markdown="span">**Allowed:** `{{ f.allowed }}`</span>{% endif %}{% if f.min_value %}<span markdown="span">**Min:** `{{ f.min_value }}`</span>{% endif %}{% if f.max_value %}<span markdown="span">**Max:** `{{ f.max_value }}`</span>{% endif %}</div>
+<div class="field-summary-header" markdown="span">
+  <strong class="field-name" id="{{ mod.modality | lower }}-{{ name | lower | replace(' ', '-') }}"><code>{{ name }}</code></strong>
+  <span class="field-type" markdown="span">{{ f.html_type }}</span>
+  {% if f.req_str == 'Yes' %}<span class="req-badge req-yes">Required</span>{% else %}<span class="req-badge req-no">Optional</span>{% endif %}
+</div>
+{% if f.short_desc %}
+<div class="field-summary-desc" markdown="span">{{ f.short_desc }}</div>
+{% endif %}
+<table class="field-meta-table">
+  <tbody>
+    <tr><td>Storage:</td><td><span markdown="span">{{ f.storage }}</span></td></tr>
+    {% if f.dimensions %}<tr><td>Dimensions:</td><td><code>{{ f.dimensions | e }}</code></td></tr>{% endif %}
+    {% if f.allowed %}<tr><td>Allowed:</td><td><code>{{ f.allowed | e }}</code></td></tr>{% endif %}
+    {% if f.min_value %}<tr><td>Min:</td><td><code>{{ f.min_value | e }}</code></td></tr>{% endif %}
+    {% if f.max_value %}<tr><td>Max:</td><td><code>{{ f.max_value | e }}</code></td></tr>{% endif %}
+  </tbody>
+</table>
 {% endset %}
 
 {% if f.description %}
@@ -251,6 +286,7 @@ details.field-details {
     box-shadow: 0 2px 2px rgba(0,0,0,0.05);
 }
 details.field-details > summary {
+    display: block !important;
     padding: 0.8rem 1rem;
     cursor: pointer;
     list-style: none;
@@ -284,28 +320,99 @@ details.empty-details > summary::after {
 details.field-details > summary:hover {
     background-color: rgba(128, 128, 128, 0.05);
 }
-details.field-details > summary .field-summary-top {
-    font-weight: 500;
-    margin-bottom: 0.2rem;
-    color: var(--md-default-fg-color);
+details.field-details > summary .field-summary-header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 0.3rem;
 }
-details.field-details > summary .field-summary-bottom {
+details.field-details > summary .field-summary-header .field-name code {
+    font-size: 1.05em;
+    color: var(--md-default-fg-color);
+    font-family: var(--md-text-font-family, inherit);
+    background: transparent;
+    padding: 0;
+    font-weight: 700;
+}
+details.field-details > summary .field-summary-header .field-type {
+    font-family: var(--md-code-font-family);
+    font-size: 0.7em;
+    font-weight: 600;
+    background-color: var(--md-primary-fg-color--lightest, rgba(64, 81, 181, 0.1));
+    color: var(--md-primary-fg-color);
+    padding: 0.15rem 0.5rem;
+    border-radius: 12px;
+    border: 1px solid var(--md-primary-fg-color--light, rgba(64, 81, 181, 0.2));
+}
+details.field-details > summary .field-summary-header .field-type a {
+    color: inherit;
+    text-decoration: underline;
+}
+details.field-details > summary .field-summary-header .field-type code {
+    background: transparent;
+    padding: 0;
+    color: inherit;
+    box-shadow: none;
+}
+details.field-details > summary .field-summary-header .req-badge {
+    font-size: 0.7em;
+    font-weight: 700;
+    padding: 0.15rem 0.5rem;
+    border-radius: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+details.field-details > summary .field-summary-header .req-yes {
+    background-color: rgba(220, 53, 69, 0.1);
+    color: #d32f2f;
+    border: 1px solid rgba(220, 53, 69, 0.2);
+}
+details.field-details > summary .field-summary-header .req-no {
+    background-color: rgba(108, 117, 125, 0.1);
+    color: #6c757d;
+    border: 1px solid rgba(108, 117, 125, 0.2);
+}
+details.field-details > summary .field-summary-desc {
+    font-size: 0.95em;
+    color: var(--md-default-fg-color);
+    margin-bottom: 0.4rem;
+    line-height: 1.4;
+    font-weight: normal;
+}
+details.field-details > summary .field-meta-table {
+    display: table !important;
+    table-layout: auto !important;
     font-size: 0.85em;
     color: var(--md-default-fg-color--light);
     margin-top: 0.4rem;
-    display: flex;
-    flex-wrap: wrap;
-    row-gap: 0.1rem;
-    column-gap: 0.5rem;
+    border-collapse: collapse;
+    width: 100%;
+    background: transparent;
+    box-shadow: none;
+    font-weight: normal;
 }
-details.field-details > summary .field-summary-bottom > span {
+details.field-details > summary .field-meta-table td {
+    display: table-cell !important;
+    padding: 0 0.75rem 0 0 !important;
+    line-height: 1.2;
+    border: none;
+    vertical-align: top;
+    background: transparent;
+}
+details.field-details > summary .field-meta-table td:nth-child(2) {
+    width: 99%;
+}
+details.field-details > summary .field-meta-table tr:hover td {
+    background: transparent;
+}
+details.field-details > summary .field-meta-table td:first-child {
+    font-weight: 600;
     white-space: nowrap;
+    width: 1%;
+    color: var(--md-default-fg-color);
 }
-details.field-details > summary .field-summary-bottom > span:not(:last-child)::after {
-    content: " •";
-    color: var(--md-default-fg-color--lightest);
-}
-details.field-details > summary .field-summary-bottom code {
+details.field-details > summary .field-meta-table code {
     font-size: 0.9em;
 }
 details.field-details[open] > summary {

--- a/tools/generate_docs.py
+++ b/tools/generate_docs.py
@@ -18,6 +18,7 @@ import yaml
 import glob
 import shutil
 import subprocess
+import generate_csv
 
 try:
     from pydantic import BaseModel, ValidationError
@@ -152,6 +153,10 @@ def main():
     
     docs_dir = os.path.join(output_dir, 'docs')
     os.makedirs(docs_dir, exist_ok=True)
+    
+    # Generate CSV to the root of the site
+    csv_output = os.path.join(docs_dir, 'ONDE_fields.csv')
+    generate_csv.generate_csv(csv_output)
     
     # Enable Math rendering via MathJax
     js_dir = os.path.join(docs_dir, 'javascripts')

--- a/tools/generate_docs.py
+++ b/tools/generate_docs.py
@@ -169,7 +169,11 @@ def main():
     processHtmlClass: "arithmatex"
   }
 };''')
-    
+
+    # Add robots.txt to prevent indexing of PR previews
+    with open(os.path.join(docs_dir, 'robots.txt'), 'w') as f:
+        f.write("User-agent: *\nDisallow: /pr-preview/\n")
+
     # Custom CSS for tighter tables
     css_dir = os.path.join(docs_dir, 'stylesheets')
     os.makedirs(css_dir, exist_ok=True)

--- a/tools/generate_docs.py
+++ b/tools/generate_docs.py
@@ -61,19 +61,27 @@ classDiagram
 
 <div class="field-list" markdown="1">
 {% for name, f in fields_meta %}
+{% set summary_content %}
+<div class="field-summary-top" markdown="span"><strong id="{{ cls.onde_class | lower }}-{{ name | lower | replace(' ', '-') }}"><code>{{ name }}</code></strong>{% if f.is_inherited %} <span class="inherited-badge" markdown="span">Inherited from [{{ f.source }}]({{ f.source | lower }}.md)</span>{% elif f.is_accessory %} <span class="accessory-badge" markdown="span">From accessory class [{{ f.source }}]({{ f.source | lower }}.md)</span>{% endif %}{% if f.short_desc %} &mdash; {{ f.short_desc }}{% endif %}</div>
+<div class="field-summary-bottom" markdown="span"><span markdown="span">**Type:** {{ f.html_type }}</span><span markdown="span">**Dimensions:** {% if f.dimensions %}`{{ f.dimensions }}`{% else %}-{% endif %}</span><span markdown="span">**Required:** {{ f.req_str }}</span><span markdown="span">**Storage:** {{ f.storage }}</span>{% if f.allowed %}<span markdown="span">**Allowed:** `{{ f.allowed }}`</span>{% endif %}{% if f.min_value %}<span markdown="span">**Min:** `{{ f.min_value }}`</span>{% endif %}{% if f.max_value %}<span markdown="span">**Max:** `{{ f.max_value }}`</span>{% endif %}</div>
+{% endset %}
+
+{% if f.description %}
 <details class="field-details{% if f.is_inherited %} inherited-field{% elif f.is_accessory %} accessory-field{% endif %}" markdown="1">
-<summary markdown="1"><div class="field-summary-top" markdown="span"><strong id="{{ cls.onde_class | lower }}-{{ name | lower | replace(' ', '-') }}"><code>{{ name }}</code></strong>{% if f.is_inherited %} <span class="inherited-badge" markdown="span">Inherited from [{{ f.source }}]({{ f.source | lower }}.md)</span>{% elif f.is_accessory %} <span class="accessory-badge" markdown="span">From accessory class [{{ f.source }}]({{ f.source | lower }}.md)</span>{% endif %} &mdash; {{ f.short_desc }}</div><div class="field-summary-bottom" markdown="span">{{ f.html_type }}</div></summary>
-
+<summary markdown="1">
+{{ summary_content }}
+</summary>
 <div class="field-content" markdown="1">
-
-{{ f.description if f.description else "No detailed description provided." }}
-
----
-
-**Type:** <span markdown="span">{{ f.html_type }}</span> | **Dimensions:** {% if f.dimensions %}`{{ f.dimensions }}`{% else %}-{% endif %} | **Required:** {{ f.req_str }} | **Storage:** {{ f.storage }}{% if f.allowed %} | **Allowed:** `{{ f.allowed }}`{% endif %}{% if f.min_value %} | **Min:** `{{ f.min_value }}`{% endif %}{% if f.max_value %} | **Max:** `{{ f.max_value }}`{% endif %}
-
+{{ f.description }}
 </div>
 </details>
+{% else %}
+<details class="field-details empty-details{% if f.is_inherited %} inherited-field{% elif f.is_accessory %} accessory-field{% endif %}" markdown="1">
+<summary onclick="event.preventDefault();" style="cursor: default;" tabindex="-1" markdown="1">
+{{ summary_content }}
+</summary>
+</details>
+{% endif %}
 {% endfor %}
 </div>
 {% endif %}
@@ -88,19 +96,27 @@ MODALITY_TEMPLATE = """\
 
 <div class="field-list" markdown="1">
 {% for name, f in fields_meta %}
+{% set summary_content %}
+<div class="field-summary-top" markdown="span"><strong id="{{ mod.modality | lower }}-{{ name | lower | replace(' ', '-') }}"><code>{{ name }}</code></strong>{% if f.short_desc %} &mdash; {{ f.short_desc }}{% endif %}</div>
+<div class="field-summary-bottom" markdown="span"><span markdown="span">**Type:** {{ f.html_type }}</span><span markdown="span">**Dimensions:** {% if f.dimensions %}`{{ f.dimensions }}`{% else %}-{% endif %}</span><span markdown="span">**Required:** {{ f.req_str }}</span><span markdown="span">**Storage:** {{ f.storage }}</span>{% if f.allowed %}<span markdown="span">**Allowed:** `{{ f.allowed }}`</span>{% endif %}{% if f.min_value %}<span markdown="span">**Min:** `{{ f.min_value }}`</span>{% endif %}{% if f.max_value %}<span markdown="span">**Max:** `{{ f.max_value }}`</span>{% endif %}</div>
+{% endset %}
+
+{% if f.description %}
 <details class="field-details" markdown="1">
-<summary markdown="1"><div class="field-summary-top" markdown="span"><strong id="{{ mod.modality | lower }}-{{ name | lower | replace(' ', '-') }}"><code>{{ name }}</code></strong> &mdash; {{ f.short_desc }}</div><div class="field-summary-bottom" markdown="span">{{ f.html_type }}</div></summary>
-
+<summary markdown="1">
+{{ summary_content }}
+</summary>
 <div class="field-content" markdown="1">
-
-{{ f.description if f.description else "No detailed description provided." }}
-
----
-
-**Type:** <span markdown="span">{{ f.html_type }}</span> | **Dimensions:** {% if f.dimensions %}`{{ f.dimensions }}`{% else %}-{% endif %} | **Required:** {{ f.req_str }} | **Storage:** {{ f.storage }}{% if f.allowed %} | **Allowed:** `{{ f.allowed }}`{% endif %}{% if f.min_value %} | **Min:** `{{ f.min_value }}`{% endif %}{% if f.max_value %} | **Max:** `{{ f.max_value }}`{% endif %}
-
+{{ f.description }}
 </div>
 </details>
+{% else %}
+<details class="field-details empty-details" markdown="1">
+<summary onclick="event.preventDefault();" style="cursor: default;" tabindex="-1" markdown="1">
+{{ summary_content }}
+</summary>
+</details>
+{% endif %}
 {% endfor %}
 </div>
 {% endif %}
@@ -189,7 +205,7 @@ def main():
     line-height: 1.3;
 }
 
-details.inherited-field > summary {
+.inherited-field > summary, .inherited-field > .field-summary-empty {
     background-color: var(--md-default-bg-color--light);
     opacity: 0.85;
 }
@@ -207,7 +223,7 @@ details.inherited-field > summary {
     text-decoration: underline;
 }
 
-details.accessory-field > summary {
+.accessory-field > summary, .accessory-field > .field-summary-empty {
     background-color: var(--md-code-bg-color);
     opacity: 0.95;
 }
@@ -226,8 +242,10 @@ details.accessory-field > summary {
 }
 
 details.field-details {
+    display: block;
     border: 1px solid var(--md-default-fg-color--lightest, rgba(0,0,0,0.12));
     border-radius: 0.2rem;
+    margin-top: 0.5rem;
     margin-bottom: 0.5rem;
     background-color: var(--md-default-bg-color);
     box-shadow: 0 2px 2px rgba(0,0,0,0.05);
@@ -260,6 +278,9 @@ details.field-details[open] > summary::before {
     transform: rotate(45deg);
     top: 1rem;
 }
+details.empty-details > summary::after {
+    display: none !important;
+}
 details.field-details > summary:hover {
     background-color: rgba(128, 128, 128, 0.05);
 }
@@ -269,22 +290,34 @@ details.field-details > summary .field-summary-top {
     color: var(--md-default-fg-color);
 }
 details.field-details > summary .field-summary-bottom {
-    font-family: var(--md-code-font-family);
     font-size: 0.85em;
     color: var(--md-default-fg-color--light);
-    word-break: break-word;
+    margin-top: 0.4rem;
+    display: flex;
+    flex-wrap: wrap;
+    row-gap: 0.1rem;
+    column-gap: 0.5rem;
+}
+details.field-details > summary .field-summary-bottom > span {
+    white-space: nowrap;
+}
+details.field-details > summary .field-summary-bottom > span:not(:last-child)::after {
+    content: " •";
+    color: var(--md-default-fg-color--lightest);
+}
+details.field-details > summary .field-summary-bottom code {
+    font-size: 0.9em;
 }
 details.field-details[open] > summary {
     border-bottom: 1px solid var(--md-default-fg-color--lightest, rgba(0,0,0,0.12));
 }
-details.field-details .field-content {
+.field-details .field-content {
     padding: 1rem;
 }
-details.field-details .field-content hr {
+.field-details .field-content hr {
     margin: 1rem 0;
 }
 ''')
-    
     # Fix the src_images path since it's one level up (ONDE-format/images)
     src_images = os.path.normpath(os.path.join(input_dir, '..', 'images'))
     dest_images = os.path.join(docs_dir, 'images')


### PR DESCRIPTION
The proposed modification introduces an ONDE_UT_EXTRACTION block that is now referenced from the Cscan dataset.
The description of the Cscan dataset has been updated to clarify that it is the entry point for data that is stored as scalar values, which can come from Ascan or Tscan data through an extraction process. The description of the extraction process has also been clarified to indicate that it describes how the Cscan data was obtained from the underlying data through NDE_UT_GATE objects.