### PR TITLE
Adding Missing Short Descriptions to All Fields

### DIFF
--- a/class_definitions/onde_2dcad.yaml
+++ b/class_definitions/onde_2dcad.yaml
@@ -29,6 +29,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Specifies the type of 2D extrusion, either PLANE or CYLINDER.'
     description: ''
     dimensions: '1'
     allowed_values: '"PLANE"|"CYLINDER"'
@@ -37,6 +38,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Defines the extrusion length for planar extrusions or the diameter for cylindrical extrusions.'
     description: ''
     dimensions: '1'
   CAD:
@@ -44,5 +46,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Contains the 2D CAD representation of the component, formatted as a DXF file.'
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_3dcad.yaml
+++ b/class_definitions/onde_3dcad.yaml
@@ -8,5 +8,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: "A 3D CAD representation of the component."
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_acquisition_grid.yaml
+++ b/class_definitions/onde_acquisition_grid.yaml
@@ -38,6 +38,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_COMPONENT>
+    short_description: The reference specimen associated with the acquisition grid.
     description: When defining an acquisition grid, it is necessary to define a reference
       specimen that is either a cylinder or a plane.
     dimensions: '1'
@@ -46,6 +47,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: Specifies whether the grid is on the inner or outer surface.
     description: Defines whether the grid is expressed in the inner surface of the
       cylinder or on the outer surface
     allowed_values: '"INNER"|"OUTER"'
@@ -54,6 +56,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: The 2D coordinate frame defining the encoding directions on the surface.
     description: 2D Frame defining the U_GRID and V_GRID directions of the encoding
       in the surface representation of the specimen (X,Y) for planar specimens, (X,THETA)
       for cylindrical specimens. (1,0,) is assumed if missing
@@ -63,6 +66,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: The targeted grid positions along the first axis (U).
     description: The specified values of the first coder at the different positions
     dimensions: '[N_U<m>]'
   V_GRID_DATA:
@@ -70,6 +74,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: The targeted grid positions along the second axis (V).
     description: The specified values of the second coder at the different positions.
       If missing while U_GRID_DATA is present, 1D array of data is assumed.
     dimensions: '[N_V<m>]'
@@ -78,6 +83,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: Indicates the scanning pattern used for the acquisition grid.
     description: |-
       Defines whether the data is ordered in the same direction for each scan
       (COMB) or is inversed every second scan (RASTER)
@@ -88,6 +94,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: The actual measured encoder values along the U axis.
     description: Obtained encoder values on the u axis
     dimensions: '[N_V<m>,N_U<m>]'
   V_ENCODER:
@@ -95,6 +102,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: The actual measured encoder values along the V axis.
     description: Obtained encoder values on the v axis
     dimensions: '[N_V<m>,N_U<m>]'
   PROBE_DIRECTION:
@@ -102,6 +110,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: The orientation of the probe within the grid's local coordinate system.
     description: |-
       For grid data, direction of the probe in the (u, v, w) coordinate system.
       Defaults to identity matrix.

--- a/class_definitions/onde_component.yaml
+++ b/class_definitions/onde_component.yaml
@@ -91,19 +91,22 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: A human-readable label or name for the component.
     description: ''
   VELOCITIES:
     full_name: ONDE_COMPONENT:VELOCITIES
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
-    description: ''
+    short_description: Longitudinal and shear wave velocities of the component.
+    description: 'The two values indicate the longitudinal and shear wave velocities respectively. Missing values should be replaced by NaN.'
     dimensions: '[2]'
   DENSITY:
     full_name: ONDE_COMPONENT:DENSITY
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: Density of the component material.
     description: ''
     dimensions: '1'
   VISUALIZATION_CAD:
@@ -111,6 +114,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: Optional CAD file used for visualization purposes.
     description: Optional CAD used for visualisation purposes
     dimensions: '1'
   VISUALIZATION_CAD_FRAME:
@@ -118,6 +122,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: Transformation frame for the visualization CAD.
     description: |-
       Definition of the frame defining the visualisation CAD with offset and
       quaternions in the specimen frame- Identity is used if absent
@@ -127,6 +132,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: Transformation defining the component's frame relative to the global reference.
     description: |-
       Definition of the specimen frame in the reference frame. If not provided,
       default value is identity with the reference frame.
@@ -136,6 +142,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: Additional text comment regarding the component.
     description: ''
     dimensions: '1'
   IMAGE:
@@ -143,5 +150,6 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: Image parameters or data associated with the component.
     description: ''
     dimensions: '[3]'

--- a/class_definitions/onde_cylinder.yaml
+++ b/class_definitions/onde_cylinder.yaml
@@ -18,5 +18,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Specifies the dimensions of the cylinder. It is a triplet containing the outer diameter, thickness, and length.'
     description: ''
     dimensions: '[3]'

--- a/class_definitions/onde_dataset.yaml
+++ b/class_definitions/onde_dataset.yaml
@@ -39,6 +39,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: A name or label representing this dataset.
     description: A name for this dataset
     dimensions: '1'
   SETUP:
@@ -46,6 +47,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_SETUP>
+    short_description: Reference to the setup configuration used for this dataset.
     description: ''
     dimensions: '1'
   OPERATOR:
@@ -53,6 +55,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: The name or identifier of the operator conducting the acquisition.
     description: ''
     dimensions: '1'
   DATE_AND_TIME:
@@ -60,6 +63,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: The date and time of the data acquisition.
     description: ''
     dimensions: '1'
   DATA:
@@ -67,6 +71,7 @@ fields:
     required: false
     storage: A or D
     hdf5_type: H5T_STD_REF_OBJ<data> or H5T_INTEGER or H5T_FLOAT
+    short_description: The core data array or a reference to the array.
     description: |-
       Data can be either an array or a reference to an array. Omitting this
       field is possible, in the event when Tscan or Cscan data is recorded but
@@ -77,6 +82,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_DIMENSION>
+    short_description: Reference to the dimension defining the amplitude characteristics.
     description: |-
       If absent, treated as coordinate "Amplitude", units "Arbitrary", offset
       0.0, scale 1.0
@@ -86,6 +92,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_DIMENSION>
+    short_description: Array of references to the index dimensions of the dataset.
     description: |-
       One entry per dimension of ONDE_DATASET:DATA. Any that are absent are
       treated as coordinate "Time", units "seconds", offset 0.0, scale 1.0

--- a/class_definitions/onde_dataset_ut_ascan.yaml
+++ b/class_definitions/onde_dataset_ut_ascan.yaml
@@ -16,6 +16,7 @@ fields:
     required: false
     storage: A or D
     hdf5_type: H5T_STD_REF_OBJ<data> or H5T_INTEGER or H5T_FLOAT
+    short_description: "Contains the time signal data array or a reference to it."
     description: |-
       Data can be either an array or a reference to an array. Omitting this
       field is possible, in the event when Tscan or Cscan data is recorded but

--- a/class_definitions/onde_dataset_ut_cscan.yaml
+++ b/class_definitions/onde_dataset_ut_cscan.yaml
@@ -69,6 +69,7 @@ fields:
     required: true
     storage: A or D
     hdf5_type: H5T_STD_REF_OBJ<data> or H5T_INTEGER or H5T_FLOAT
+    short_description: References to arrays containing scalar raw data or data resulting from analysis of signals.
     description: references to arrays containing the different values stored in the
       dataset
     dimensions: '[N_CS<m>] |[N_CS<m>,N_Gate<m>]'
@@ -77,6 +78,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_STRING
+    short_description: A string defining the nature of the stored data, such as a custom property or a standardized name.
     description: |-
       string defining the stored data - the name can be either custom
       (MY_MATERIAL_PROPERTY for instance) or a standardized name: THICKNESS,
@@ -87,6 +89,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_ASCAN_DATASET> or H5T_STD_REF_OBJ<ONDE_UT_TSCAN_DATASET>
+    short_description: A reference to the dataset containing the originating underlying raw data.
     description: reference to the dataset containing the underlying data
     dimensions: '1'
   UNDERLYING_DATA_REFERENCE:
@@ -94,6 +97,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_INTEGER
+    short_description: A mapping that provides the correspondence between the C-scan scalar data and its originating scan.
     description: |-
       Correspondancy between the C-Scan scalar data and the scan originating.
       For a A-Scan, the scan is expressed in terms of (dataframe, law). For a 2D
@@ -105,6 +109,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_ACQUISITION_GRID>
+    short_description: A reference to a grid-type trajectory block used to position the C-scan data.
     description: ''
     dimensions: '1'
   GATES:
@@ -112,5 +117,6 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_GATE>
+    short_description: References to separate gate groups that define the time windows and thresholds used for data acquisition.
     description: ''
     dimensions: '[N_Gate<m>]'

--- a/class_definitions/onde_dataset_ut_tscan.yaml
+++ b/class_definitions/onde_dataset_ut_tscan.yaml
@@ -54,6 +54,7 @@ description: |-
 fields:
   DATA:
     full_name: ONDE_DATASET:DATA
+    short_description: Contains the reconstructed T-scan data values.
     required: true
     storage: A or D
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_ASCAN_DATASET> or H5T_INTEGER
@@ -61,6 +62,7 @@ fields:
     dimensions: 1 or [N_U<m>,N_V<m>,N_ROW<m>,N_COL<m>] or [N_U<m>,N_V<m>,NROW<m>,NCOL<m>,N_PLANE<m>]
   ZONE_FRAME:
     full_name: ONDE_DATASET_UT_TSCAN:ZONE_FRAME
+    short_description: Defines the coordinate frame associated with the center of the image zone.
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
@@ -68,6 +70,7 @@ fields:
     dimensions: '[7]'
   ZONE_DIMENSION:
     full_name: ONDE_DATASET_UT_TSCAN:ZONE_DIMENSION
+    short_description: Specifies the physical dimensions of the reconstruction zone.
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
@@ -75,6 +78,7 @@ fields:
     dimensions: '[3]'
   ZONE_SIZE:
     full_name: ONDE_DATASET_UT_TSCAN:ZONE_SIZE
+    short_description: Defines the number of pixels along each axis of the reconstruction zone.
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
@@ -82,6 +86,7 @@ fields:
     dimensions: '[3]'
   RECONSTRUCTION_MODE:
     full_name: ONDE_DATASET_UT_TSCAN:RECONSTRUCTION_MODE
+    short_description: Specifies the mode or algorithm used for the reconstruction.
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
@@ -89,6 +94,7 @@ fields:
     dimensions: '1'
   REFERENCE_PROBE_INDEX:
     full_name: ONDE_DATASET_UT_TSCAN:REFERENCE_PROBE_INDEX
+    short_description: Indicates the index of the reference probe used for trajectory alignment.
     required: false
     storage: attribute
     hdf5_type: H5T_INTEGER
@@ -98,6 +104,7 @@ fields:
     dimensions: '1'
   SOURCE_ASCAN_DATASET:
     full_name: ONDE_DATASET_UT_TSCAN:SOURCE_ASCAN_DATASET
+    short_description: Points to the elementary channel A-scans dataset used for this reconstruction.
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_ASCAN_DATASET>

--- a/class_definitions/onde_dimension.yaml
+++ b/class_definitions/onde_dimension.yaml
@@ -4,6 +4,7 @@ description: ''
 fields:
   COORDINATE:
     full_name: ONDE_DIMENSION:COORDINATE
+    short_description: 'Name of the stored data or indexed coordinates.'
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
@@ -18,6 +19,7 @@ fields:
     dimensions: '1'
   UNITS:
     full_name: ONDE_DIMENSION:UNITS
+    short_description: 'Units for the stored data or indexed coordinates, preferably spelled-out MKS base units.'
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
@@ -33,6 +35,7 @@ fields:
     dimensions: '1'
   OFFSET:
     full_name: ONDE_DIMENSION:OFFSET
+    short_description: 'Offset value to be added to the scaled stored data or zero-based indices.'
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
@@ -44,6 +47,7 @@ fields:
     dimensions: '1'
   SCALE:
     full_name: ONDE_DIMENSION:SCALE
+    short_description: 'Scaling factor applied to the stored data or integer indices.'
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT

--- a/class_definitions/onde_dual_wedge.yaml
+++ b/class_definitions/onde_dual_wedge.yaml
@@ -8,6 +8,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: Distance between the probes in a dual probe setup.
     description: For dual probes, inter-probes distance (L6) (See Figure 15)
     dimensions: '1'
   ROOF_ANGLE:
@@ -15,6 +16,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: The roof angle for a dual probe wedge.
     description: |-
       For dual probes and only for dual probes defines the roof angle (See
       Figure 15)
@@ -24,5 +26,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: The squint angle of the dual probe wedge.
     description: For dual probes, squint angle (A2) (See Figure 15)
     dimensions: '1'

--- a/class_definitions/onde_geometric_setup.yaml
+++ b/class_definitions/onde_geometric_setup.yaml
@@ -20,6 +20,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_COMPONENT>
+    short_description: Reference to the inspected component.
     description: |-
       Reference to the inspected component. If missing, semi-infinite half plane
       is assumed, with interface at z=0 and material for z>0
@@ -29,6 +30,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_PROBE>
+    short_description: List of all probes used in the acquisition of the dataset.
     description: List all probes used in the acquisition of the dataset
     dimensions: '[N_Prob<M>]'
   ACQUISITION_TRAJECTORY:
@@ -36,6 +38,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_ACQUISITION_TRAJECTORY>
+    short_description: References to the block describing the trajectory.
     description: |-
       References to the block describing the trajectory, references have the
       same order as PROBE_LIST
@@ -45,6 +48,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: Offset and direction of the probe with respect to the trajectory frame.
     description: |-
       Offset and direction of the probe w.r.t the trajectory frame- identity is
       assumed if not provided

--- a/class_definitions/onde_immersion.yaml
+++ b/class_definitions/onde_immersion.yaml
@@ -8,5 +8,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The designated path length through the water couplant during immersion."
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_linear_ut_probe.yaml
+++ b/class_definitions/onde_linear_ut_probe.yaml
@@ -9,6 +9,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_INTEGER
     description: ''
+    short_description: 'The total number of individual ultrasonic elements in this linear array probe.'
     dimensions: '1'
   ELEMENT_DIM_MAJOR:
     full_name: ONDE_LINEAR_UT_PROBE:ELEMENT_DIM_MAJOR
@@ -16,6 +17,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The dimension of a single element along the primary axis of the linear array.'
     dimensions: '1'
   ELEMENT_DIM_MINOR:
     full_name: ONDE_LINEAR_UT_PROBE:ELEMENT_DIM_MINOR
@@ -23,6 +25,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The dimension of a single element along the secondary axis (transverse to the array).'
     dimensions: '1'
   ELEMENT_PITCH_DIM_MAJOR:
     full_name: ONDE_LINEAR_UT_PROBE:ELEMENT_PITCH_DIM_MAJOR
@@ -30,6 +33,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The center-to-center spacing between adjacent elements along the primary axis of the linear array.'
     dimensions: '1'
   ELEMENT_NUMBERING:
     full_name: ONDE_LINEAR_UT_PROBE:ELEMENT_NUMBERING
@@ -40,4 +44,5 @@ fields:
       Defines the element numbering relating the numbering implicitly defined by
       the probe description and the order defined in the element tables
       (ELEMENT_POSITION, ELEMENT_GEOMETRY, etc)
+    short_description: 'Mapping between the probe''s physical element order and the indices used in the data tables.'
     dimensions: '[N_Elem<p>]'

--- a/class_definitions/onde_matrix_ut_probe.yaml
+++ b/class_definitions/onde_matrix_ut_probe.yaml
@@ -8,6 +8,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: 'Total number of elements in the matrix ultrasonic probe.'
     description: ''
     dimensions: '1'
   NUMBER_OF_ELEMENTS_DIM_MINOR:
@@ -15,6 +16,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: 'The number of elements along the minor dimension of the matrix probe.'
     description: ''
     dimensions: '1'
   ELEMENT_DIM_MAJOR:
@@ -22,6 +24,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Size of a single element along the major dimension.'
     description: ''
     dimensions: '1'
   ELEMENT_DIM_MINOR:
@@ -29,6 +32,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Size of a single element along the minor dimension.'
     description: ''
     dimensions: '1'
   ELEMENT_PITCH_DIM_MAJOR:
@@ -36,6 +40,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The pitch (center-to-center distance) between elements along the major dimension.'
     description: ''
     dimensions: '1'
   ELEMENT_PITCH_DIM_MINOR:
@@ -43,6 +48,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The pitch (center-to-center distance) between elements along the minor dimension.'
     description: ''
     dimensions: '1'
   ELEMENT_NUMBERING:
@@ -50,6 +56,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_INTEGER
+    short_description: 'Defines the element numbering relating the implicitly defined numbering and the order in the element tables.'
     description: |-
       Defines the element numbering relating the numbering implicitly defined by
       the probe description and the order defined in the element tables

--- a/class_definitions/onde_phased_array_angle.yaml
+++ b/class_definitions/onde_phased_array_angle.yaml
@@ -12,6 +12,7 @@ description: |-
 fields:
   BSCAN_ANGLE:
     full_name: ONDE_PHASED_ARRAY_ANGLE:BSCAN_ANGLE
+    short_description: "The specified angle for the ultrasonic ray direction."
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT

--- a/class_definitions/onde_phased_array_compound.yaml
+++ b/class_definitions/onde_phased_array_compound.yaml
@@ -23,6 +23,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The initial angle of the scope for the compound scan."
     description: ''
     dimensions: '1'
   FINAL_ANGLE:
@@ -30,6 +31,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The final angle of the scope for the compound scan."
     description: ''
     dimensions: '1'
   NUMBER_OF_ANGLES:
@@ -37,6 +39,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: "The total number of angles defined within the compound scan scope."
     description: ''
     dimensions: '1'
   NUMBER_OF_ELEMENTS:
@@ -44,5 +47,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: "The number of elements involved in the electronic scanning process."
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_phased_array_escan.yaml
+++ b/class_definitions/onde_phased_array_escan.yaml
@@ -19,6 +19,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: 'The number of consecutive elements used to form a beam.'
     description: ''
     dimensions: '1'
   STEP:
@@ -26,6 +27,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: 'The number of elements by which the subset is shifted for each successive beam.'
     description: ''
     dimensions: '1'
   ANGLE:
@@ -33,5 +35,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The specific angle at which the beam is formed during the scan.'
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_phased_array_pwi.yaml
+++ b/class_definitions/onde_phased_array_pwi.yaml
@@ -8,6 +8,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The starting angle for the plane wave imaging (PWI) sweep.'
     description: ''
     dimensions: '1'
   FINISHING_ANGLE:
@@ -15,6 +16,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The finishing angle for the plane wave imaging (PWI) sweep.'
     description: ''
     dimensions: '1'
   NUMBER_OF_ANGLES:
@@ -22,5 +24,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: 'The total number of discrete angles used in the plane wave imaging (PWI) sweep.'
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_phased_array_setup.yaml
+++ b/class_definitions/onde_phased_array_setup.yaml
@@ -27,6 +27,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_PROBE>
+    short_description: "Reference to the emitting phased array probe used in this setup."
     description: ''
     dimensions: '1'
   RECEIVING_PROBE:
@@ -34,6 +35,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_PROBE>
+    short_description: "Reference to the receiving phased array probe used in this setup."
     description: ''
     dimensions: '1'
   SEQUENCE_ANGLE_MODE:
@@ -41,5 +43,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: "Specifies the wave propagation mode used for the setup sequence, such as longitudinal (L) or transverse (T)."
     description: ''
     allowed_values: '"L"|"T"'

--- a/class_definitions/onde_phased_array_sscan.yaml
+++ b/class_definitions/onde_phased_array_sscan.yaml
@@ -18,6 +18,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The first emission or reception angle in the linearly varying set for the SScan."
     description: ''
     dimensions: '1'
   FINISHING_ANGLE:
@@ -25,6 +26,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The final emission or reception angle in the linearly varying set for the SScan."
     description: ''
     dimensions: '1'
   NUMBER_OF_ANGLES:
@@ -32,5 +34,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_INTEGER
+    short_description: "The total number of shots or linearly varying angles defining the set for the SScan."
     description: ''
     dimensions: '1'

--- a/class_definitions/onde_plane.yaml
+++ b/class_definitions/onde_plane.yaml
@@ -17,5 +17,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "The dimensions of the planar specimen, represented as a triplet of length, width, and thickness."
     description: ''
     dimensions: '[3]'

--- a/class_definitions/onde_setup.yaml
+++ b/class_definitions/onde_setup.yaml
@@ -9,6 +9,7 @@ fields:
     full_name: ONDE_SETUP:GEOMETRIC_SETUP
     required: true
     storage: attribute
+    short_description: "Reference to the geometric setup configuration."
     hdf5_type: H5T_STD_REF_OBJ<ONDE_GEOMETRIC_SETUP>
     description: ''
     dimensions: '[1]'

--- a/class_definitions/onde_setup_ut.yaml
+++ b/class_definitions/onde_setup_ut.yaml
@@ -8,5 +8,6 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_ULTRASONIC_SETUP>
+    short_description: Defines the ultrasonic setup configuration for the sequence.
     description: Mandatory for Ascan sequences
     dimensions: '[1]'

--- a/class_definitions/onde_spatial_trajectory.yaml
+++ b/class_definitions/onde_spatial_trajectory.yaml
@@ -27,6 +27,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: A 3D array detailing the positions and orientations of the acquisition frame across the trajectory. Each point is defined by 3D coordinates and a quaternion.
     description: |-
       List of positions and quaternions giving the positions and orientations of
       the trajectory frame at the different positions

--- a/class_definitions/onde_time_trajectory.yaml
+++ b/class_definitions/onde_time_trajectory.yaml
@@ -12,5 +12,6 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "Defines the acquisition rate for time encoded trajectories."
     description: For time encoded trajectories, defines the acquisition rate
     dimensions: '1'

--- a/class_definitions/onde_ultrasonic_setup.yaml
+++ b/class_definitions/onde_ultrasonic_setup.yaml
@@ -84,6 +84,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Label for the ultrasonic setup.'
     description: ''
     dimensions: '1'
   RECTIFICATION:
@@ -91,6 +92,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Defines the rectification mode applied to the ultrasonic data.'
     description: |-
       Defines if the data are FULL_WAVE or RECTIFIED_POSITIVE,
       RECTIFIED_NEGATIVE, RECTIFIED_FULL
@@ -100,6 +102,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Specifies the type of filtering applied to the signals.'
     description: |-
       Defines the type of filtering applied to the signals: NO_FILTER,
       LOW_PASS, HIGH_PASS, BAND_PASS, OTHER
@@ -109,6 +112,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Provides the parameters for the analogue filter.'
     description: |-
       Optional datafield providing analogue filter parameters - see notes for
       detailed explanation
@@ -118,6 +122,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'A textual description of the filtering applied.'
     description: Description of the filtering applied
     dimensions: '1'
   ASCAN_SAMPLE_RATE:
@@ -125,6 +130,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The sampling frequency of the A-scan data points.'
     description: |-
       This indicates the sampling frequency of A-scan data points. It is assumed
       that a uniform sampling rate is used throughout A-scan data collection.
@@ -134,6 +140,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The starting time for data acquisition.'
     description: |-
       This indicates the starting time for data acquisition. If dimension is 1,
       the same start time is used for all A-Scans, else a different start time
@@ -144,6 +151,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'Digitization of the emission signal.'
     description: |-
       Digitization of the emission signal (can be used to store arbitrary
       signals). If missing impulse emission at time 0.0 is assumed. 2D Array
@@ -154,6 +162,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The total gain applied for each A-scan during reception.'
     description: |-
       This indicates the total gain for each A-scan during
       reception. Multiplying factor that was applied at acquisition.
@@ -163,6 +172,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The Pulse Repetition Frequency (PRF) for the signals.'
     description: Pulse Repetition Frequency
     dimensions: '[N_Ascan<m>] or [2]'
   TCG_CURVE:
@@ -170,6 +180,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The Time Corrected Gain (TCG) curve applied to the received signals.'
     description: |-
       TCG curve applied to the received signals. The amplitude correction is
       given for each time sample as a multiplying factor.
@@ -179,6 +190,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_PHASED_ARRAY_SETUP>
+    short_description: 'Reference to the associated phased array setup.'
     description: ''
     dimensions: '1'
   TRANSMIT_LAW:
@@ -186,6 +198,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_LAW>
+    short_description: 'HDF5 reference to the transmit focal law group.'
     description: |-
       Each A-scan in a dataframe must be associated with both a transmit and a
       receive focal law through the datafields. These contain HDF5 references to
@@ -198,6 +211,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_LAW>
+    short_description: 'HDF5 reference to the receive focal law group.'
     description: |-
       Each A-scan in a dataframe must be associated with both a transmit and a
       receive focal law through the datafields. These contain HDF5 references to

--- a/class_definitions/onde_ut.yaml
+++ b/class_definitions/onde_ut.yaml
@@ -49,6 +49,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Identifies the file type as an ONDE UT file.'
     description: |-
       For detailed information, see
       https://github.com/COFREND/ONDE-format/blob/main/UT_specification/UT_file_format.md
@@ -59,6 +60,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Specifies the version of the ONDE UT specification that this file conforms to.'
     description: ''
     dimensions: '1'
     allowed_values: '"0.9.1"'

--- a/class_definitions/onde_ut_coupling.yaml
+++ b/class_definitions/onde_ut_coupling.yaml
@@ -8,6 +8,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: "The velocity of the acoustic waves propagating within the coupling medium."
     dimensions: '[2]'
   MEDIUM_DENSITY:
     full_name: ONDE_UT_COUPLING:MEDIUM_DENSITY
@@ -15,6 +16,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: "The density of the coupling medium."
     dimensions: '1'
   INCIDENCE_ANGLE:
     full_name: ONDE_UT_COUPLING:INCIDENCE_ANGLE
@@ -22,4 +24,5 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: "The angle of incidence of the acoustic wave as it travels into the coupling medium."
     dimensions: '1'

--- a/class_definitions/onde_ut_elements.yaml
+++ b/class_definitions/onde_ut_elements.yaml
@@ -59,6 +59,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'Defines the position and orientation of each probe element.'
     description: Array defining the location of the elements of the probe
     dimensions: '[N_Elem<p>,7]'
   SHAPE:
@@ -66,6 +67,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_INTEGER
+    short_description: 'Specifies the geometric shape of each probe element.'
     description: 'The shape of each element will be defined as one of the following:
       rectangle (ELE_GEOM_REC), part of a ring (ELE_GEOM_RING_PART), part of an elliptical
       ring (ELE_GEOM_ELLIPSE_PART),'
@@ -75,6 +77,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'Provides six parameters that specify the dimensions of each element.'
     description: ''
     dimensions: '[N_Elem<p>,6]'
   RADIUS_OF_CURVATURE:
@@ -82,6 +85,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The radius of curvature for elements that are not flat.'
     description: If absent, flat elements are assumed
     dimensions: '[N_Elem<p>]'
   AXIS_OF_CURVATURE:
@@ -89,6 +93,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The vector defining the axis of curvature for non-flat elements.'
     description: If absent, flat elements are assumed
     dimensions: '[N_Elem<p>,3]'
   DEAD_ELEMENT:
@@ -96,6 +101,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_INTEGER
+    short_description: 'Logical flags indicating non-functioning elements in a probe.'
     description: |-
       Datafield of logical values (0 = false, 1 = true) used to flag
       non-functioning elements in an array probe (if not present, assumption

--- a/class_definitions/onde_ut_gate.yaml
+++ b/class_definitions/onde_ut_gate.yaml
@@ -7,6 +7,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "Defines the start time for the ultrasonic gate."
     description: |-
       For scalar data relying on Ascan data, defines the start time for the
       gate. Mandatory for data related to Ascans.
@@ -16,6 +17,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "Defines the width of the ultrasonic gate."
     description: |-
       For Cscans scalar data relying on Ascan data, defines the width of the
       gate. Mandatory for data related to Ascans
@@ -25,6 +27,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: "Defines the threshold of the gate for data storage."
     description: Defines the threshold of the gate for data to be stored
     dimensions: '1'
   DETECTION:
@@ -32,6 +35,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: "Specifies the peak or flank detection mode for the gate."
     description: ''
     dimensions: '1'
     allowed_values: '"FIRST_PEAK"|"LAST_PEAK"|"MAX_PEAK"|"FIRST_FLANK"|"LAST_FLANK"|"MAX_FLANK"'
@@ -40,6 +44,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: "Specifies the polarity used for gate detection."
     description: ''
     dimensions: '1'
     allowed_values: '"ABSOLUTE"|"POSITIVE"|"NEGATIVE"'

--- a/class_definitions/onde_ut_law.yaml
+++ b/class_definitions/onde_ut_law.yaml
@@ -17,6 +17,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_PROBE>
+    short_description: 'A reference to the ultrasonic probe used in this focal law.'
     description: ''
     dimensions: '[N_C<k>]'
   ELEMENT:
@@ -24,6 +25,7 @@ fields:
     required: true
     storage: dataset
     hdf5_type: H5T_INTEGER
+    short_description: 'The index or identifier of the probe element used in this focal law.'
     description: ''
     dimensions: '[N_C<k>]'
   DELAY:
@@ -31,6 +33,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The relative delay applied to each probe element combination.'
     description: |-
       Specifies the relative delay (in ultrasonic time) between the different
       Probe Element Combinations in the focal law. The default value is zero
@@ -41,6 +44,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The weighting factor applied to each probe element combination.'
     description: |-
       Specifies the weighting between the different Probe Element Combinations
       in the focal law. The default is one for all Probe Element Combinations.
@@ -50,6 +54,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'The ultrasonic ray along which the data is to be represented.'
     description: |-
       Represents the ultrasonic ray along which the data is to be represented in
       a true visualisation. It contains at least two points in the Probe

--- a/class_definitions/onde_ut_probe.yaml
+++ b/class_definitions/onde_ut_probe.yaml
@@ -37,6 +37,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Type tags for the UT probe.'
     description: ''
     dimensions: '[1]'
     allowed_values: '["ONDE_UT_ELEMENTS"]'
@@ -45,6 +46,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Human-readable label for the probe.'
     description: ''
     dimensions: '1'
   MANUFACTURER:
@@ -52,6 +54,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'The manufacturer of the probe.'
     description: ''
     dimensions: '1'
   SERIAL_NUMBER:
@@ -59,6 +62,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'The serial number of the probe.'
     description: ''
     dimensions: '1'
   FREQUENCY:
@@ -66,6 +70,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The operating frequency of the probe.'
     description: ''
     dimensions: '1'
   BANDWIDTH:
@@ -73,6 +78,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'The frequency bandwidth of the probe.'
     description: ''
     dimensions: '1'
   INDEX_POINT_FRAME:
@@ -80,6 +86,7 @@ fields:
     required: false
     storage: dataset
     hdf5_type: H5T_FLOAT
+    short_description: 'Frame of reference for the index point of the probe.'
     description: If absent, identity is assumed
     dimensions: '[7]'
   FOCUSING_SURFACE:
@@ -87,6 +94,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Shape of the surface on which the elements are arranged.'
     description: |-
       Defines the shape of the surface on which the elements are arranged —if
       absent, FLAT is assumed
@@ -96,6 +104,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Geometric parameters defining the focusing surface.'
     description: |-
       Multi values: value in mm
 
@@ -113,5 +122,6 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STD_REF_OBJ<ONDE_UT_COUPLING>
+    short_description: 'Reference to the coupling system used with the probe.'
     description: Reference to the coupling system (wedge, immersion, direct)
     dimensions: '1'

--- a/class_definitions/onde_wedge.yaml
+++ b/class_definitions/onde_wedge.yaml
@@ -74,6 +74,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Label or identifier for the wedge.'
     description: ''
     dimensions: '1'
   MANUFACTURER:
@@ -81,6 +82,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Manufacturer of the wedge.'
     description: ''
     dimensions: '1'
   SERIAL_NUMBER:
@@ -88,6 +90,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Serial number of the wedge.'
     description: ''
     dimensions: '1'
   CONTACT_SURFACE:
@@ -95,6 +98,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_STRING
+    short_description: 'Type of the wedge contact surface.'
     description: |-
       Type of the wedge contact surface - PLANAR, SPHERICAL, CYLINDRICAL_MAJOR,
       CYLINDRICAL_MINOR - If missing PLANAR assumed
@@ -104,6 +108,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Radius of curvature for the wedge contact surface.'
     description: |-
       Wedge curvature radius (0 assumed if missing)
 
@@ -117,6 +122,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Dimensions defining the equivalent contact area of the wedge.'
     description: Equivalent to L1, L2 and L3 (See Figure 15)
     dimensions: '[3]'
   HEIGHT:
@@ -124,6 +130,7 @@ fields:
     required: true
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Distance of the ultrasonic beam between the probe center and the index point.'
     description: |-
       For a wedge, distance of the ultrasonic beam between the probe center and
       the index point (See Figure 15)
@@ -133,6 +140,7 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Skew angle of the wedge.'
     description: wedge /skew angle (B) (See Figure 15)
     dimensions: '1'
   DISORIENTATION_ANGLE:
@@ -140,5 +148,6 @@ fields:
     required: false
     storage: attribute
     hdf5_type: H5T_FLOAT
+    short_description: 'Disorientation angle of the wedge.'
     description: wedge /disorientation angle (D) (See Figure 15)
     dimensions: '1'

--- a/class_definitions/onde_weld.yaml
+++ b/class_definitions/onde_weld.yaml
@@ -9,6 +9,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_STRING
     description: ''
+    short_description: 'Specifies the type of extrusion for the weld geometry.'
     dimensions: '1'
     allowed_values: '"PLANE"|"CYLINDER"'
   EXTRUSION_DIMENSION:
@@ -17,6 +18,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The physical dimension used for the weld extrusion process.'
     dimensions: '1'
   WELD_TYPE:
     full_name: ONDE_WELD:WELD_TYPE
@@ -24,6 +26,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_STRING
     description: ''
+    short_description: 'Specifies the shape type of the weld groove (e.g., V or U).'
     dimensions: '1'
     allowed_values: '"V"|"U"'
   WELD_SYMMETRY:
@@ -32,6 +35,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_STRING
     description: ''
+    short_description: 'Describes the symmetry configuration of the weld geometry.'
     dimensions: '1'
     allowed_values: '"SYMMETRIC"|"STRAIGHT_LEFT"|"STRAIGHT_RIGHT"'
   WELD_UPPER_CAP_WIDTH:
@@ -40,6 +44,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The width of the upper cap of the weld.'
     dimensions: '1'
   WELD_UPPER_CAP_HEIGHT:
     full_name: ONDE_WELD:WELD_UPPER_CAP_HEIGHT
@@ -47,6 +52,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the upper cap of the weld.'
     dimensions: '1'
   WELD_FILL_ANGLE:
     full_name: ONDE_WELD:WELD_FILL_ANGLE
@@ -54,6 +60,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The angle of the fill pass for the weld.'
     dimensions: '1'
   WELD_FILL_HEIGHT:
     full_name: ONDE_WELD:WELD_FILL_HEIGHT
@@ -61,6 +68,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the fill pass for the weld.'
     dimensions: '1'
   WELD_HOT_PASS_ANGLE:
     full_name: ONDE_WELD:WELD_HOT_PASS_ANGLE
@@ -68,6 +76,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The angle of the hot pass layer in the weld.'
     dimensions: '1'
   WELD_HOT_PASS_HEIGHT:
     full_name: ONDE_WELD:WELD_HOT_PASS_HEIGHT
@@ -75,6 +84,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the hot pass layer in the weld.'
     dimensions: '1'
   WELD_LAND_OFFSET:
     full_name: ONDE_WELD:WELD_LAND_OFFSET
@@ -82,6 +92,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The offset measurement for the root land of the weld.'
     dimensions: '1'
   WELD_LAND_HEIGHT:
     full_name: ONDE_WELD:WELD_LAND_HEIGHT
@@ -89,6 +100,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the root land of the weld.'
     dimensions: '1'
   WELD_ROOT_ANGLE:
     full_name: ONDE_WELD:WELD_ROOT_ANGLE
@@ -96,6 +108,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The angle of the root pass for the weld.'
     dimensions: '1'
   WELD_ROOT_HEIGHT:
     full_name: ONDE_WELD:WELD_ROOT_HEIGHT
@@ -103,6 +116,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the root pass for the weld.'
     dimensions: '1'
   WELD_LOWER_CAP_HEIGHT:
     full_name: ONDE_WELD:WELD_LOWER_CAP_HEIGHT
@@ -110,6 +124,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The height of the lower cap of the weld.'
     dimensions: '1'
   WELD_LOWER_CAP_WIDTH:
     full_name: ONDE_WELD:WELD_LOWER_CAP_WIDTH
@@ -117,6 +132,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The width of the lower cap of the weld.'
     dimensions: '1'
   WELD_HAZ_WIDTH:
     full_name: ONDE_WELD:WELD_HAZ_WIDTH
@@ -124,4 +140,5 @@ fields:
     storage: attribute
     hdf5_type: H5T_FLOAT
     description: ''
+    short_description: 'The width of the heat-affected zone (HAZ) of the weld.'
     dimensions: '1'

--- a/tools/generate_csv.py
+++ b/tools/generate_csv.py
@@ -57,7 +57,8 @@ def generate_csv():
             'required': True,
             'storage': 'attribute',
             'hdf5_type': 'H5T_STRING',
-            'description': '',
+            'short_description': 'Specifies the ONDE class and its inheritance hierarchy.',
+            'description': 'The `ONDE:TYPE` attribute dictates the semantic meaning of the HDF5 group. It contains a 1D array of strings that traces the class inheritance from the root class down to this specific class.',
             'dimensions': dim_str,
             'allowed_values': allowed_str
         }

--- a/tools/generate_docs.py
+++ b/tools/generate_docs.py
@@ -356,7 +356,8 @@ details.field-details .field-content hr {
             required=True,
             storage="attribute",
             hdf5_type="H5T_STRING",
-            description="",
+            short_description="Specifies the ONDE class and its inheritance hierarchy.",
+            description="The `ONDE:TYPE` attribute dictates the semantic meaning of the HDF5 group. It contains a 1D array of strings that traces the class inheritance from the root class down to this specific class.",
             dimensions=dim_str,
             allowed_values=allowed_str
         )


### PR DESCRIPTION
This is in response to Issue #78 trying to start filling in missing information in the YAML files.  This pull request contains a commit that should serve as a starting point for having at least something filled in for every field.  

There are a number of cases where more useful information could probably be provided (or where additional detail is absolutely needed in the long description) but that get at more fundamental questions where I'm not sure we have direct answers to these questions yet.  For instance, a number of probe parameters should probably explicitly define the units being used directly in the short description.  (We might even consider explicitly adding a units field to the YAML for this purpose.)

There are also cases where the long description is redundant.  I'm planning to go through those next.  We could do that as a part of this PR if desired, or I'll do it separately later.

Nothing in this pull request should be changing anything substantive about the format.  However, this PR likely needs a more careful review and will likely require changes.  For those with edit access to the repo, feel free to just directly make changes.  For others, feel free to post a comment or request an edit on the appropriate line and I'll make the updates.