### PR TITLE
Fixed base class ordering in the .csv

### DIFF
--- a/tools/generate_csv.py
+++ b/tools/generate_csv.py
@@ -31,6 +31,7 @@ def generate_csv():
             
     # Inject TYPE fields dynamically based on inheritance for classes
     def get_inheritance_chain_dict(c_name, visited=None):
+        """returns inheritance list with base class last"""
         if visited is None: visited = set()
         if c_name in visited or not c_name: return []
         visited.add(c_name)
@@ -48,9 +49,10 @@ def generate_csv():
     for c_data in classes_data:
         cls_name = c_data.get('onde_class', '')
         
-        chain = get_inheritance_chain_dict(cls_name)
-        allowed_str = '["' + '", "'.join(chain) + '"]'
-        dim_str = f'[{len(chain)}]' if len(chain) > 1 else '1'
+        # Obtain inheritance list with base class first
+        chain_fwd = get_inheritance_chain_dict(cls_name)[::-1]
+        allowed_str = '["' + '", "'.join(chain_fwd) + '"]'
+        dim_str = f'[{len(chain_fwd)}]' if len(chain_fwd) > 1 else '1'
         
         type_field = {
             'full_name': 'ONDE:TYPE',

--- a/tools/generate_csv.py
+++ b/tools/generate_csv.py
@@ -31,7 +31,7 @@ def generate_csv():
             
     # Inject TYPE fields dynamically based on inheritance for classes
     def get_inheritance_chain_dict(c_name, visited=None):
-        """returns inheritance list with base class last"""
+        """returns inheritance list with base class first"""
         if visited is None: visited = set()
         if c_name in visited or not c_name: return []
         visited.add(c_name)
@@ -42,7 +42,7 @@ def generate_csv():
         inherits = c_data.get('inherits', [])
         chain = [c_name]
         for parent in inherits:
-            chain.extend(get_inheritance_chain_dict(parent, visited))
+            chain = get_inheritance_chain_dict(parent, visited) + chain # list concatenation
         
         return chain
 
@@ -50,9 +50,9 @@ def generate_csv():
         cls_name = c_data.get('onde_class', '')
         
         # Obtain inheritance list with base class first
-        chain_fwd = get_inheritance_chain_dict(cls_name)[::-1]
-        allowed_str = '["' + '", "'.join(chain_fwd) + '"]'
-        dim_str = f'[{len(chain_fwd)}]' if len(chain_fwd) > 1 else '1'
+        chain = get_inheritance_chain_dict(cls_name)
+        allowed_str = '["' + '", "'.join(chain) + '"]'
+        dim_str = f'[{len(chain)}]' if len(chain) > 1 else '1'
         
         type_field = {
             'full_name': 'ONDE:TYPE',


### PR DESCRIPTION
The generated csv's have the class ordering in ONDE:TYPE derived class first, not base class first. This pull request makes them base class first like they should be.