### PR TITLE
Switch ONDE:FILETYPE to be a set of tags indicating how file should be interpreted/processed

### DIFF
--- a/class_definitions/onde_ut.yaml
+++ b/class_definitions/onde_ut.yaml
@@ -53,7 +53,7 @@ fields:
       For detailed information, see
       https://github.com/COFREND/ONDE-format/blob/main/UT_specification/UT_file_format.md
     dimensions: '1'
-    allowed_values: '"ONDE_UT"'
+    allowed_values: '["ONDE_DATASET"]'
   VERSION:
     full_name: ONDE:VERSION
     required: true

--- a/specification/data_model.md
+++ b/specification/data_model.md
@@ -23,7 +23,7 @@ Classes define fields that can be:
 
 ### File type
 The extension of the HDF5 file is ".onde" (for Open Non Destructive Evaluation format).
-The HDF5 root group must contain an attribute called `ONDE:FILETYPE` and a `ONDE:VERSION` attribute. The file is identified as a UT ONDE file because of the `ONDE:FILETYPE` attribute which is given at the root of the structure. The version of the file points to the version of the present specification.
+The HDF5 root group must contain an attribute called `ONDE:FILETYPE` and a `ONDE:VERSION` attribute. The file is identified as an ONDE file because of the `ONDE:FILETYPE` attribute which is given at the root of the structure. The `ONDE:FILETYPE` attribute is treated as a set of tags indicating how the file should be interpreted or processed (order of multiple tags is not significant). In this version of the specification, only a single tag is defined, 'ONDE_DATASET', which indicates that this file should be searched for HDF5 groups representing instances of the ONDE_DATASET class or subclasses as discussed in [the ONDE overview](overview.md). The `ONDE:VERSION` attribute is a string that identifies the version number of the present specification.
 
 ### HDF5 implementation of classes
 In ONDE, an object corresponding to a class in the data model translates into an HDF5 group. The class of the object is given by a particular HDF5 attribute of the HDF5 group. This attribute is named `ONDE:TYPE` and contains a 1D array of strings. The HDF5 name of the group is left free for the implementation decision.

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -207,11 +207,11 @@ ONDE_DATASET_UT_TSCAN or ONDE_DATASET_UT_CSCAN)
 
 When discovering the content of a given file, the following procedure must therefore be applied:
 
-- Read the 'ONDE_FILETYPE' and 'ONDE_VERSION' attributes at root level and verify the compatibility of the version number with the
-  reader, and that the type is that of a UT ONDE file ('ONDE_UT')
+- Read the 'ONDE:FILETYPE' and 'ONDE:VERSION' attributes at root level and verify the compatibility of the version number with the
+  reader, and that the filetype attribute (which is a list/array) contains as one of its elements the string 'ONDE_DATASET' indicating that the file is an ONDE file which contains datasets.
 - Read all groups in the file and identify the groups corresponding to the datasets blocks by checking
-  which groups have a 'TYPE' attribute whose value is 'ONDE_DATASET_UT_ASCAN', 'ONDE_DATASET_UT_TSCAN', 'ONDE_DATASET_UT_CSCAN'.
-- From there follow the HDF5 references defined in the specification to retrieve the data arrays, the related datasets, the
+  which groups have a 'ONDE:TYPE' attribute whose value is a list starting with 'ONDE_DATASET'. This will identify all ONDE datasets stored in the file. The 'ONDE:TYPE' field is a list that defines the class derivation of the object being represented. Interpret the object based on the rightmost (most derived) class listed that you understand.
+- From there interpret the contents of the HDF5 group according to references defined in the specification to retrieve the data arrays, the related datasets, the
   setup information…
 
 ## Definition of frames


### PR DESCRIPTION
This pull request switches ONDE:FILETYPE from being a modality indicator to being a set of tags which indicate how the file should be interpreted/processed. So far, one tag is defined. Specifically, ONDE_DATASET indicates the file contains datasets.

Addresses issue #49 