### PR TITLE
Change allowed_classes to expected_classes acknowledging the intrinsic extensibility of ONDE.

### DIFF
--- a/class_definitions/onde_ut.yaml
+++ b/class_definitions/onde_ut.yaml
@@ -2,8 +2,8 @@ modality: ONDE_UT
 description: |
   ### ONDE UT File
 
-  This class specifies the UT file type and provides a place for including top level fields. It explicitly references all of the classes that are allowed in this file type.
-allowed_classes:
+  This class specifies the UT file type and provides a place for including top level fields. It explicitly references all of the classes that are expected in this file type.
+expected_classes:
   - ONDE_DATASET
   - ONDE_DATASET_UT
   - ONDE_DATASET_UT_ASCAN

--- a/tools/generate_csv.py
+++ b/tools/generate_csv.py
@@ -67,8 +67,8 @@ def generate_csv():
         new_fields.update(fields)
         c_data['fields'] = new_fields
             
-    # Sort to ensure consistent output based on modality allowed_classes
-    ordered_classes = modalities_data[0].get('allowed_classes', []) if modalities_data else []
+    # Sort to ensure consistent output based on modality expected_classes
+    ordered_classes = modalities_data[0].get('expected_classes', []) if modalities_data else []
     
     def get_sort_key(x):
         c_name = x.get('onde_class', '')

--- a/tools/generate_docs.py
+++ b/tools/generate_docs.py
@@ -105,12 +105,12 @@ MODALITY_TEMPLATE = """\
 </div>
 {% endif %}
 
-{% if mod.allowed_classes %}
+{% if mod.expected_classes %}
 ## Classes of Relevance
 
 The following classes are allowed in this modality in order:
 
-{% for c_name, c_link in allowed_classes_links -%}
+{% for c_name, c_link in expected_classes_links -%}
 {% if c_link %}- [{{ c_name }}]({{ c_link }}){% else %}- {{ c_name }}{% endif %}
 {% endfor %}
 {% endif %}
@@ -648,16 +648,16 @@ details.field-details .field-content hr {
                     }
                     fields_meta.append((fname, meta))
                     
-                allowed_classes_links = []
-                for c_name in mod_obj.allowed_classes:
+                expected_classes_links = []
+                for c_name in mod_obj.expected_classes:
                     to_chain = get_inheritance_chain(c_name)
                     link = "../" + "/".join(c.lower() for c in to_chain) + "/index.md" if to_chain else ""
-                    allowed_classes_links.append((c_name, link))
+                    expected_classes_links.append((c_name, link))
                     
                 md_content = Template(MODALITY_TEMPLATE).render(
                     mod=mod_obj,
                     fields_meta=fields_meta,
-                    allowed_classes_links=allowed_classes_links
+                    expected_classes_links=expected_classes_links
                 )
                 f.write(md_content)
             nav_lines.append(f"    - {mod_name}: implementations/{mod_filename}")

--- a/tools/schema_classes.py
+++ b/tools/schema_classes.py
@@ -23,5 +23,5 @@ class OndeClass(BaseModel):
 class OndeModality(BaseModel):
     modality: str
     description: str = ""
-    allowed_classes: List[str] = []
+    expected_classes: List[str] = []
     fields: Dict[str, OndeField] = {}


### PR DESCRIPTION
ONDE allows arbitrary subclassing and externally defined accessory classes. In addition, future versions will likely define additional classes. Thus, "allowed_classes" is a bit of a misnomer. This pull request changes the terminology to "expected_classes".