### PR TITLE
Make DATE_AND_TIME field much more specific and require a "T" separator

### DIFF
--- a/class_definitions/onde_dataset.yaml
+++ b/class_definitions/onde_dataset.yaml
@@ -5,8 +5,7 @@ description: |
 
   ### Generic remarks on datasets
 
-  The DATE_AND_TIME and OPERATOR fields allow to give indication on the context of the acquisition. For DATE_AND_TIME the
-  ISO 8601 extended format: 'yyyy-mm-dd HH:MM:SS' (e.g. '2019-01-16 17:05:06') must be used.
+  The DATE_AND_TIME and OPERATOR fields allow to give indication on the context of the acquisition. 
 
   ### Notes on groups
 
@@ -57,10 +56,14 @@ fields:
     dimensions: '1'
   DATE_AND_TIME:
     full_name: ONDE_DATASET:DATE_AND_TIME
-    required: false
+    required: true
     storage: attribute
     hdf5_type: H5T_STRING
-    description: ''
+    description: |-
+    The ISO 8601 extended format: 'yyyy-mm-ddTHH:MM:SS' (e.g. '2019-01-16T17:05:06') must be used with a capital T separating the date and the time. Optionally, a decimal point ('.') and a fractional portion of a second may be appended. In addition, time zone information is usually appended:
+      * "Z", indicating a timestamp in UTC
+      * "±hh:mm", indicating a timezone with the specified offset from UTC
+      * (no timezone information), indicating an unknown timezone; software will usually interpret this as local time or UTC. 
     dimensions: '1'
   DATA:
     full_name: ONDE_DATASET:DATA

--- a/class_definitions/onde_dataset.yaml
+++ b/class_definitions/onde_dataset.yaml
@@ -60,7 +60,7 @@ fields:
     storage: attribute
     hdf5_type: H5T_STRING
     description: |-
-    The ISO 8601 extended format: 'yyyy-mm-ddTHH:MM:SS' (e.g. '2019-01-16T17:05:06') must be used with a capital T separating the date and the time. Optionally, a decimal point ('.') and a fractional portion of a second may be appended. In addition, time zone information is usually appended:
+      The ISO 8601 extended format: 'yyyy-mm-ddTHH:MM:SS' (e.g. '2019-01-16T17:05:06') must be used with a capital T separating the date and the time. Optionally, a decimal point ('.') and a fractional portion of a second may be appended. In addition, time zone information is usually appended:
       * "Z", indicating a timestamp in UTC
       * "±hh:mm", indicating a timezone with the specified offset from UTC
       * (no timezone information), indicating an unknown timezone; software will usually interpret this as local time or UTC. 


### PR DESCRIPTION
This addresses issue #71 