### PR TITLE
Move ASCAN_START from ONDE_ULTRASONIC_SETUP to ONDE_DATASET_UT_ASCAN and clean up dimensions and documentation

### DIFF
--- a/class_definitions/onde_dataset_ut_ascan.yaml
+++ b/class_definitions/onde_dataset_ut_ascan.yaml
@@ -37,5 +37,5 @@ fields:
        2. Capture triggered by hardware gates where each scan point can have a different start time.
        3. Capture with multiple receivers that have different gain settings for different portions of the waveform.
       Note that ASCAN_START does not affect the interpretation of the last of the ONDE_DATASET:INDEX_DIMENSIONS, which also describes the time dimension of the data. When there are multiple different values for ASCAN_START, the ONDE_DIMENSION:COORDINATE for that last dimension should be clear about the interpretation based on the ONDE_DIMENSION:OFFSET (which is limited to scalar values), e.g. "Time after channel acquistion start"
-    dimensions: [ N_U<m>, N_V<m>, N_Ascan<m>] but any or all of these dimensions can be dropped to 1, in which case the given values are broadcast along those dimensions.
+    dimensions: "[ N_U<m>, N_V<m>, N_Ascan<m>] but any or all of these dimensions can be dropped to 1, in which case the given values are broadcast along those dimensions."
     

--- a/class_definitions/onde_dataset_ut_ascan.yaml
+++ b/class_definitions/onde_dataset_ut_ascan.yaml
@@ -20,7 +20,7 @@ fields:
       Data can be either an array or a reference to an array. Omitting this
       field is possible, in the event when Tscan or Cscan data is recorded but
       the underlying Ascan data is not.
-    dimensions: 1 or [N_U<m>,N_V<m>,N_Ascan<m>,Ntime<m>]
+    dimensions: "1 or [N_U<m>,N_V<m>,N_Ascan<m>,Ntime<m>]"
 
   ASCAN_START:
     full_name: ONDE_DATASET_UT_ASCAN:ASCAN_START

--- a/class_definitions/onde_dataset_ut_ascan.yaml
+++ b/class_definitions/onde_dataset_ut_ascan.yaml
@@ -21,3 +21,21 @@ fields:
       field is possible, in the event when Tscan or Cscan data is recorded but
       the underlying Ascan data is not.
     dimensions: 1 or [N_U<m>,N_V<m>,N_Ascan<m>,Ntime<m>]
+
+  ASCAN_START:
+    full_name: ONDE_DATASET_UT_ASCAN:ASCAN_START
+    required: false
+    storage: dataset
+    hdf5_type: H5T_FLOAT
+    description: |-
+      This indicates the starting time for data acquisition. If dimension is 1,
+      the same start time is used for all A-Scans, else a different start time
+      is specified for each A-Scan.
+
+      ASCAN_START is intended for three different use cases:
+       1. Phased array capture where different elements capture starting at different times, and
+       2. Capture triggered by hardware gates where each scan point can have a different start time.
+       3. Capture with multiple receivers that have different gain settings for different portions of the waveform.
+      Note that ASCAN_START does not affect the interpretation of the last of the ONDE_DATASET:INDEX_DIMENSIONS, which also describes the time dimension of the data. When there are multiple different values for ASCAN_START, the ONDE_DIMENSION:COORDINATE for that last dimension should be clear about the interpretation based on the ONDE_DIMENSION:OFFSET (which is limited to scalar values), e.g. "Time after channel acquistion start"
+    dimensions: [ N_U<m>, N_V<m>, N_Ascan<m>] but any or all of these dimensions can be dropped to 1, in which case the given values are broadcast along those dimensions.
+    

--- a/class_definitions/onde_ultrasonic_setup.yaml
+++ b/class_definitions/onde_ultrasonic_setup.yaml
@@ -12,9 +12,9 @@ description: |-
     - the sampling frequency
     - the dimension of data N_Time<m>
 
-    t0 : ASCAN_ASTART
+    t0 : ONDE_DATASET_UT_ASCAN:ASCAN_ASTART
 
-    tend : ASCAN_ASTART + (N_Time<m> - 1) / ASCAN_SAMPLE_RATE
+    tend : ONDE_DATASET_UT_ASCAN:ASCAN_ASTART + (N_Time<m> - 1) / ASCAN_SAMPLE_RATE
 
     #### Gain
 
@@ -129,16 +129,6 @@ fields:
       This indicates the sampling frequency of A-scan data points. It is assumed
       that a uniform sampling rate is used throughout A-scan data collection.
     dimensions: '1'
-  ASCAN_START:
-    full_name: ONDE_ULTRASONIC_SETUP:ASCAN_START
-    required: true
-    storage: dataset
-    hdf5_type: H5T_FLOAT
-    description: |-
-      This indicates the starting time for data acquisition. If dimension is 1,
-      the same start time is used for all A-Scans, else a different start time
-      is specified for each A-Scan.
-    dimensions: 1 or [N_Ascan<m>] or [ N_Ascan<m>,N_U<m>, N_V<m>]
   SIGNAL:
     full_name: ONDE_ULTRASONIC_SETUP:SIGNAL
     required: false


### PR DESCRIPTION
In a recent technical committee meeting or user group meeting it was brought up that hardware gates can cause the start time of each recorded ASCAN to be different. I (S. Holland) was tasked with updating the spec to support such functionality. 

On closer inspection,  relevant functionality was already present in the form of ONDE_ULTRASONIC_SETUP:ASCAN_START. However, the dimensions and ordering didn't make sense. In addition, it does not really make sense to include data output (hardware gate timing) under SETUP. Finally, it was suggested that the initial time field should support broadcasting over arbitrary axes.

This pull request moves ONDE_ULTRASONIC_SETUP:ASCAN_START to ONDE_DATASET_UT_ASCAN:ASCAN_START and cleans it up and documents it better.