### PR TITLE
Add a binary file abstraction for CAD models and images

### DIFF
--- a/class_definitions/onde_2dcad.yaml
+++ b/class_definitions/onde_2dcad.yaml
@@ -43,6 +43,7 @@ fields:
     full_name: ONDE_2DCAD:CAD
     required: true
     storage: attribute
-    hdf5_type: H5T_STRING
-    description: ''
+    hdf5_type: H5T_STD_REF_OBJ<ONDE_BINARYFILE>
+    description: |
+      Contains the CAD file itself. The recommended format is DXF with a CONTENT_TYPE of "image/vnd.dxf". Applications should warn or otherwise get consent from the end-user before embedding a non-recommended format.
     dimensions: '1'

--- a/class_definitions/onde_3dcad.yaml
+++ b/class_definitions/onde_3dcad.yaml
@@ -7,6 +7,11 @@ fields:
     full_name: ONDE_3DCAD:CAD
     required: true
     storage: attribute
-    hdf5_type: H5T_STRING
-    description: ''
+    hdf5_type: H5T_STD_REF_OBJ<ONDE_BINARYFILE>
+    description: |
+      Contains the CAD file itself. The recommended formats are:
+       * STEP with a CONTENT_TYPE of "model/step", "model/step+xml", "model/step+zip", or "model/step-xml+zip". Exactly which of the preceding CONTENT_TYPEs is specified should not be treated as significant. The step file should contain application protocols AP203, AP214, or AP242.
+       * IGES with a CONTENT_TYPE of "application/iges"
+       * STL with a CONTENT_TYPE of "model/stl", "model/x.stl-ascii", "model/x.stl-binary". Exactly which of the preceding CONTENT_TYPEs is specified should not be treated as significant.
+      Applications should warn or otherwise get consent from the end-user before embedding a non-recommended format.
     dimensions: '1'

--- a/class_definitions/onde_binaryfile.yaml
+++ b/class_definitions/onde_binaryfile.yaml
@@ -2,4 +2,5 @@ onde_class: ONDE_BINARYFILE
 inherits: []
 description: |
   ## The ONDE_BINARYFILE is an abstract base class for containers for arbitrary file content. It is assumed that the content is accessible by some means, and will have a specified MIME type
-fields:
+fields: {}
+

--- a/class_definitions/onde_binaryfile.yaml
+++ b/class_definitions/onde_binaryfile.yaml
@@ -1,0 +1,25 @@
+onde_class: ONDE_BINARYFILE
+inherits: []
+description: |
+  ## The ONDE_BINARYFILE is a container for arbitrary file content with a specified MIME type
+fields:
+  CONTENT:
+    full_name: ONDE_BINARYFILE:CONTENT
+    required: true
+    storage: dataset
+    hdf5_type: H5T_NATIVE_OPAQUE
+    description: The bytes of the binary file
+    dimensions: '[N_bytes]'
+  CONTENT_TYPE:
+    full_name: ONDE_BINARYFILE:CONTENT_TYPE
+    required: true
+    storage: attribute
+    hdf5_type: H5T_STRING
+    description: The MIME type of the file provided. May be "application/octet-string" for unknown binary data.
+  NAME:
+    full_name: ONDE_BINARYFILE:NAME
+    required: false
+    storage: attribute
+    hdf5_type: H5T_STRING
+    description: An optional file name identifying the contained information.
+  

--- a/class_definitions/onde_binaryfile.yaml
+++ b/class_definitions/onde_binaryfile.yaml
@@ -1,25 +1,5 @@
-onde_class: ONDE_BINARYFILE
+onde_class: ONDE_BINARYFILE 
 inherits: []
 description: |
-  ## The ONDE_BINARYFILE is a container for arbitrary file content with a specified MIME type
+  ## The ONDE_BINARYFILE is an abstract base class for containers for arbitrary file content. It is assumed that the content is accessible by some means, and will have a specified MIME type
 fields:
-  CONTENT:
-    full_name: ONDE_BINARYFILE:CONTENT
-    required: true
-    storage: dataset
-    hdf5_type: H5T_NATIVE_OPAQUE
-    description: The bytes of the binary file
-    dimensions: '[N_bytes]'
-  CONTENT_TYPE:
-    full_name: ONDE_BINARYFILE:CONTENT_TYPE
-    required: true
-    storage: attribute
-    hdf5_type: H5T_STRING
-    description: The MIME type of the file provided. May be "application/octet-string" for unknown binary data.
-  NAME:
-    full_name: ONDE_BINARYFILE:NAME
-    required: false
-    storage: attribute
-    hdf5_type: H5T_STRING
-    description: An optional file name identifying the contained information.
-  

--- a/class_definitions/onde_binaryfile_embedded.yaml
+++ b/class_definitions/onde_binaryfile_embedded.yaml
@@ -1,0 +1,25 @@
+onde_class: ONDE_BINARYFILE_EMBEDDED
+inherits: ONDE_BINARYFILE 
+description: |
+  ## The ONDE_BINARYFILE_EMBEDDED is a container for arbitrary file content that is embedded within the ONDE file and that has a specified MIME type
+fields:
+  CONTENT:
+    full_name: ONDE_BINARYFILE_EMBEDDED:CONTENT
+    required: true
+    storage: dataset
+    hdf5_type: H5T_NATIVE_OPAQUE
+    description: The bytes of the binary file
+    dimensions: '[N_bytes]'
+  CONTENT_TYPE:
+    full_name: ONDE_BINARYFILE_EMBEDDED:CONTENT_TYPE
+    required: true
+    storage: attribute
+    hdf5_type: H5T_STRING
+    description: The MIME type of the file provided. May be "application/octet-string" for unknown binary data.
+  NAME:
+    full_name: ONDE_BINARYFILE_EMBEDDED:NAME
+    required: false
+    storage: attribute
+    hdf5_type: H5T_STRING
+    description: An optional file name identifying the contained information.
+  

--- a/class_definitions/onde_binaryfile_embedded.yaml
+++ b/class_definitions/onde_binaryfile_embedded.yaml
@@ -1,5 +1,6 @@
 onde_class: ONDE_BINARYFILE_EMBEDDED
-inherits: ONDE_BINARYFILE 
+inherits:
+- ONDE_BINARYFILE 
 description: |
   ## The ONDE_BINARYFILE_EMBEDDED is a container for arbitrary file content that is embedded within the ONDE file and that has a specified MIME type
 fields:

--- a/class_definitions/onde_component.yaml
+++ b/class_definitions/onde_component.yaml
@@ -60,14 +60,6 @@ description: |-
 
     #### Visualization CAD
 
-    When a dxf is provided for the Visualization CAD, the extrusion of the CAD
-    is implied from the specimen shape: it is of linear nature if the specimen
-    is a plate or a 2D CAD with linear extrusion, it is cylindrical if the
-    specimen is a cylinder or a 2D CAD with cylindrical extrusion. A typical use
-    case for this feature is the ability to superimpose a weld profile to a
-    plate or cylindrical specimen in order to facilitate the interpretation of
-    the indications.
-
     The CAD profiles that are used for visualization are expressed in the (X,Z)
     plane as specified in the specimen frame. [Figure 10](onde_component.md)
     illustrates the CAD frame positioning to the component frame for a planar
@@ -110,8 +102,22 @@ fields:
     full_name: ONDE_COMPONENT:VISUALIZATION_CAD
     required: false
     storage: attribute
-    hdf5_type: H5T_STRING
-    description: Optional CAD used for visualisation purposes
+    hdf5_type: H5T_STD_REF_OBJ<ONDE_BINARYFILE>
+    description: |
+      Optional CAD used for visualisation purposes. Contains the CAD file itself. The recommended formats are:
+       * STEP with a CONTENT_TYPE of "model/step", "model/step+xml", "model/step+zip", or "model/step-xml+zip". Exactly which of the preceding CONTENT_TYPEs is specified should not be treated as significant. The step file should contain application protocols AP203, AP214, or AP242.
+       * IGES with a CONTENT_TYPE of "application/iges"
+       * STL with a CONTENT_TYPE of "model/stl", "model/x.stl-ascii", "model/x.stl-binary". Exactly which of the preceding CONTENT_TYPEs is specified should not be treated as significant.
+       * DXF with a CONTENT_TYPE of "image/vnd.dxf".
+      Applications should warn or otherwise get consent from the end-user before embedding a non-recommended format.
+
+      When a dxf is provided for the Visualization CAD, the extrusion of the CAD
+      is implied from the specimen shape: it is of linear nature if the specimen
+      is a plate or a 2D CAD with linear extrusion, it is cylindrical if the
+      specimen is a cylinder or a 2D CAD with cylindrical extrusion. A typical use
+      case for this feature is the ability to superimpose a weld profile to a
+      plate or cylindrical specimen in order to facilitate the interpretation of
+      the indications.
     dimensions: '1'
   VISUALIZATION_CAD_FRAME:
     full_name: ONDE_COMPONENT:VISUALIZATION_CAD_FRAME
@@ -142,6 +148,11 @@ fields:
     full_name: ONDE_COMPONENT:IMAGE
     required: false
     storage: attribute
-    hdf5_type: H5T_FLOAT
-    description: ''
-    dimensions: '[3]'
+    hdf5_type: H5T_STD_REF_OBJ<ONDE_BINARYFILE>
+    description: |
+      Photograph or other image of the component.
+      Recommended formats are:
+       * PNG with a CONTENT_TYPE of "image/png"
+       * JPEG with a CONTENT_TYPE of "image/jpeg"      
+      Applications should warn or otherwise get consent from the end-user before embedding a non-recommended format.
+    dimensions: '1'

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -119,6 +119,7 @@ Definitions (derived from MFMC 2.0.0b specification)
 | N_PLANE\<m\>  | Number of planes in the image zone for a 3D Tscan in the m-th dataset    |
 | N_U\<m\>      | Number of acquisition positions in the U direction for the m-th dataset  | 
 | N_V\<m\>      | Number of acquisition positions in the V direction for the m-th dataset  |
+| N_bytes       | Number of bytes |
 
 Note: N_DF\<m\> = N_U\<m\> x N_V\<m\>
 


### PR DESCRIPTION
This PR addresses issue #87 by defining a binary file abstraction and referencing it where CAD models or images are needed. 